### PR TITLE
add package.json for publishing to npmjs.org

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "scratchblocks2",
+  "version": "2.0.1",
+  "description": "Render Scratch blocks code to HTML.",
+  "directories": {
+    "test": "tests"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/blob8108/scratchblocks2"
+  },
+  "keywords": [
+    "scratch",
+    "scratchblocks",
+    "scratchblocks2",
+    "code",
+    "block"
+  ],
+  "author": "blob8108",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/blob8108/scratchblocks2/issues"
+  },
+  "homepage": "https://github.com/blob8108/scratchblocks2"
+}


### PR DESCRIPTION
Issue #49.
Simply pull this and do `npm publish` (you'll have to create an account).

If you would like to create your own package.json, use `npm init` when in root. Entry point (default index.js) is not really needed, as this is not a node package - see [What is a module?](https://www.npmjs.org/doc/misc/npm-faq.html). As this is set default, I have removed it from package.json after `npm init`.

Quoting the relevant part:
_Most npm packages are modules, because they are libraries that you load with require. However, there's no requirement that an npm package be a module! Some only contain an executable command-line interface, and don't provide a main field for use in Node programs._
