### PR TITLE
Support strings in round parentheses

### DIFF
--- a/index.html
+++ b/index.html
@@ -265,6 +265,7 @@ function objUpdated() {
 
   var doc = window.doc = scratchblocks.parse(obj.script, {
     languages: obj.lang ? ['en', obj.lang] : ['en'],
+    dialect: 'scratch3',
   });
 
   // doc.translate(scratchblocks.allLanguages['de']);

--- a/syntax/syntax.js
+++ b/syntax/syntax.js
@@ -89,6 +89,7 @@ function paintBlock(info, children, languages, couldBeString) {
   if (couldBeString) {
     var input = new Input("string", string)
     // Store info in case this turns out to be a standalone reporter
+    input.stringBlockInfo = info
     return input
   }
 
@@ -299,6 +300,16 @@ function parseLines(code, languages, dialect) {
         (child.isReporter || child.isBoolean || child.isRing)
       ) {
         return child
+      }
+
+      // In scratch3 dialect strings can be in round parentheses
+      // but if we see this at the top-level, we cheat and assume it's a variable reporter
+      if (child.stringBlockInfo) {
+        var info = child.stringBlockInfo
+        info.category = "variables"
+        var block = new Block(info, [new Label(child.value)])
+        // nb. we skip image replacement here because we _probably_ don't need it
+        return block
       }
     }
 

--- a/syntax/syntax.js
+++ b/syntax/syntax.js
@@ -879,6 +879,15 @@ function parse(code, options) {
     options
   )
 
+  switch (options.dialect) {
+    case DialectClassic:
+      break
+    case DialectScratch3:
+      break
+    default:
+      throw new Error("Unknown dialect: " + options.dialect)
+  }
+
   code = code.replace(/&lt;/g, "<")
   code = code.replace(/&gt;/g, ">")
   if (options.inline) {

--- a/tests/syntax.test.js
+++ b/tests/syntax.test.js
@@ -113,6 +113,11 @@ describe('scratch3 dialect', () => {
   test('define hats', () => {
     testBlockScratch3('define foo (num) if <bool>', ['procDef', 'foo %n if %b', ['num', 'bool'], [1, false], false])
   })
+
+  test('standalone reporters', () => {
+    testBlock('(foo)', ['readVariable', 'foo'])
+    testBlockScratch3('(foo)', ['readVariable', 'foo'])
+  })
 })
 
 

--- a/tests/syntax.test.js
+++ b/tests/syntax.test.js
@@ -159,7 +159,42 @@ describe('recognise lists', () => {
       ['showList:', 'list'],
     ])
   })
+
+  test('in scratch3 dialect', () => {
+    testScriptScratch3('say (list)\nshow list [list v]', [
+      ['say:', ['contentsOfList:', 'list']],
+      ['showList:', 'list'],
+    ])
+  })
 })
+
+describe('recognise scratch3 variables', () => {
+  test('not a variable', () => {
+    testBlockScratch3('say (string)', ['say:', 'string'])
+  })
+
+  test('from set command', () => {
+    testScriptScratch3('say (foo)\nset [foo v] to (quxx)', [
+      ['say:', ['readVariable', 'foo']],
+      ['setVar:to:', 'foo', 'quxx'],
+    ])
+  })
+
+  test('from show command', () => {
+    testScriptScratch3('say (foo)\nshow variable [foo v]', [
+      ['say:', ['readVariable', 'foo']],
+      ['showVariable:', 'foo'],
+    ])
+  })
+
+  test('ignore square strings', () => {
+    testScriptScratch3('say [foo]\nshow variable [foo v]', [
+      ['say:', 'foo'],
+      ['showVariable:', 'foo'],
+    ])
+  })
+})
+
 
 describe('disambiguation', () => {
   test('green: length of string', () => {

--- a/tests/syntax.test.js
+++ b/tests/syntax.test.js
@@ -105,6 +105,17 @@ describe('literals', () => {
 
 })
 
+describe('scratch3 dialect', () => {
+  test('parses parentheses as strings', () => {
+    testBlockScratch3('say (Hello!) for (foo) secs', ['say:duration:elapsed:from:', 'Hello!', 'foo'])
+  })
+
+  test('define hats', () => {
+    testBlockScratch3('define foo (num) if <bool>', ['procDef', 'foo %n if %b', ['num', 'bool'], [1, false], false])
+  })
+})
+
+
 describe('color literals', () => {
   test('work', () => {
     let b = testBlock('<touching color [#f0f] ?>', ["touchingColor:", 16711935])


### PR DESCRIPTION
In Scratch 3, string inputs are usually round (I believe they're round if they accept dropping a variable reporter). We can of course render them however we like; but it would be potentially confusing if writing `say (Hi!)` didn't work! This PR introduces separate **dialects** for the parser. In the new `scratch3` dialect, round parentheses are treated as strings.

Of course, currently we default to assuming that round parentheses are variables, e.g. `(foo)`. You can force scratchblocks to render it as a variable using the ` :: variables` override. But I've also added logic to "recognise" variables based on menu inputs, like we do for lists. So if you write

```
say (foo)
set [foo v] to (1)
```
...then scratchblocks can infer that `(foo)` is a variable, since you've used as a variable menu option.