### PR TITLE
fix: process unicode icons correctly

### DIFF
--- a/syntax/blocks.js
+++ b/syntax/blocks.js
@@ -155,7 +155,7 @@ function loadLanguage(code, language) {
     var m = iconPat.exec(spec)
     if (m) {
       var image = m[0]
-      var hash = nativeHash.replace(image, unicodeIcons[image])
+      var hash = nativeHash.replace(hashSpec(image), unicodeIcons[image])
       blocksByHash[hash] = block
     }
   })


### PR DESCRIPTION
Close #245 

This PR fixes the bug where unicode icons (`⚑`, `↻`, `↺`, `▸`, and `◂`) are ignored.
I've confirmed `npm start` and `npm run test` worked well.
