### PR TITLE
build: generate sourcemap in development

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "build": "rollup -c --environment buildTarget:PROD; exit 0;",
     "fmt": "prettier --write *.js syntax/*.js scratch2/*.js scratch3/*.js locales-src/*.js snapshots/*.js",
     "lint:staged": "lint-staged",
-    "start": "rollup -c -w",
+    "start": "rollup -c -m -w",
     "rollup": "rollup -c",
     "locales": "node locales-src/build-locales.js",
     "test": "jest",


### PR DESCRIPTION
Tweak rollup options in `start` script to generate sourcemap. It makes easy to debug the code by allowing us to identify the place in the original (i.e. non-minified) code where errors occur.

```
-m, --sourcemap             Generate sourcemap (`-m inline` for inline map)
```