### PR TITLE
Provide multiple hash for blocks that contains parenthesis

### DIFF
--- a/syntax/blocks.js
+++ b/syntax/blocks.js
@@ -133,7 +133,13 @@ function loadLanguage(code, language) {
     var block = blocksBySpec[spec]
 
     var nativeHash = hashSpec(nativeSpec)
-    blocksByHash[nativeHash] = block
+    var regOptional = /\(.*\)/;
+    if( nativeHash.search(regOptional) != -1 ){
+      blocksByHash[nativeHash.replace('(', '').replace(')', '')] = block
+      blocksByHash[nativeHash.replace(regOptional, '')] = block
+    } else {
+      blocksByHash[nativeHash] = block
+    }
 
     // fallback image replacement, for languages without aliases
     var m = iconPat.exec(spec)


### PR DESCRIPTION
https://github.com/scratchblocks/scratchblocks/issues/308

This patch will generate multiple hash for block label that contains parenthesis.

The result will be looking like this:

![image](https://user-images.githubusercontent.com/7746142/64312981-164b3a00-cfe5-11e9-9864-453deff6a69b.png)

Left : rendered by scratchblocks
Right : what is actually seen in scratch editor.