### PR TITLE
fix: centerize a string in a reporter when adding a padding

### DIFF
--- a/scratch3/blocks.js
+++ b/scratch3/blocks.js
@@ -510,6 +510,7 @@ BlockView.prototype.draw = function() {
   // Commands have a minimum width
   // The hat min-width is arbitrary (not sure of Scratch 3 value)
   // Outline min-width is deliberately higher (because Scratch 3 looks silly)
+  var orgInnerWidth = innerWidth
   innerWidth = Math.max(
     this.hasScript
       ? 160
@@ -518,6 +519,7 @@ BlockView.prototype.draw = function() {
         : this.isCommand || this.isOutline ? 64 : this.isReporter ? 48 : 0,
     innerWidth
   )
+  padLeft += (innerWidth - orgInnerWidth) / 2
   this.height = y
 
   this.width = scriptWidth ? Math.max(innerWidth, 15 + scriptWidth) : innerWidth

--- a/scratch3/blocks.js
+++ b/scratch3/blocks.js
@@ -519,6 +519,7 @@ BlockView.prototype.draw = function() {
         : this.isCommand || this.isOutline ? 64 : this.isReporter ? 48 : 0,
     innerWidth
   )
+  // Center the label text inside small reporters.
   padLeft += (innerWidth - orgInnerWidth) / 2
   this.height = y
 

--- a/scratch3/blocks.js
+++ b/scratch3/blocks.js
@@ -510,7 +510,7 @@ BlockView.prototype.draw = function() {
   // Commands have a minimum width
   // The hat min-width is arbitrary (not sure of Scratch 3 value)
   // Outline min-width is deliberately higher (because Scratch 3 looks silly)
-  var orgInnerWidth = innerWidth
+  var originalInnerWidth = innerWidth
   innerWidth = Math.max(
     this.hasScript
       ? 160
@@ -520,7 +520,7 @@ BlockView.prototype.draw = function() {
     innerWidth
   )
   // Center the label text inside small reporters.
-  padLeft += (innerWidth - orgInnerWidth) / 2
+  padLeft += (innerWidth - originalInnerWidth) / 2
   this.height = y
 
   this.width = scriptWidth ? Math.max(innerWidth, 15 + scriptWidth) : innerWidth


### PR DESCRIPTION
Close #330

![image](https://user-images.githubusercontent.com/436237/80051457-281d2580-8553-11ea-97f2-b7a6b5578a22.png)
