### PR TITLE
added Event_whenstageclicked to commands.js

### DIFF
--- a/syntax/commands.js
+++ b/syntax/commands.js
@@ -509,6 +509,13 @@ module.exports = [
     category: "events",
   },
   {
+    id: "EVENT_WHENSTAGECLICKED",
+    spec: "when stage clicked",
+    inputs: [],
+    shape: "hat",
+    category: "events",
+  },
+  {
     id: "EVENT_WHENBACKDROPSWITCHESTO",
     selector: "whenSceneStarts",
     spec: "when backdrop switches to %1",


### PR DESCRIPTION
Added support for the block "event_whenstageclicked". Could not find the 'selector' for this block. Please refer to Issue #332 for more information regarding this PR!