### PR TITLE
fix: make child variable reassignable

### DIFF
--- a/syntax/syntax.js
+++ b/syntax/syntax.js
@@ -96,7 +96,7 @@ function paintBlock(info, children, languages) {
       )
 
       for (let i = 0; i < outlineChildren.length; i++) {
-        const child = outlineChildren[i]
+        let child = outlineChildren[i]
         if (child.isInput && child.isBoolean) {
           // Convert empty boolean slot to empty boolean argument.
           child = paintBlock(


### PR DESCRIPTION
`child` variable is defined as `const`, but it could be re-assigned, so use `let` instead of `const`.