### PR TITLE
Allow CSS to modify the sizing of blocks while maintaining the aspect ratio

### DIFF
--- a/scratch2/draw.js
+++ b/scratch2/draw.js
@@ -66,6 +66,7 @@ var SVG = (module.exports = {
       version: "1.1",
       width: width,
       height: height,
+      viewBox: `0 0 ${width} ${height}`,
     })
   },
 

--- a/scratch3/draw.js
+++ b/scratch3/draw.js
@@ -66,6 +66,7 @@ var SVG = (module.exports = {
       version: "1.1",
       width: width,
       height: height,
+      viewBox: `0 0 ${width} ${height}`,
     })
   },
 


### PR DESCRIPTION
**Summary**
Allows CSS to modify the sizing of blocks while maintaining the aspect ratio.

**Description**
This project aims for [pixel perfect accuracy of blocks](https://github.com/scratchblocks/scratchblocks/issues/265#issue-391385570), so it is important that adding this value didn't change the size of the original blocks. Since there are existing `height`  and `width` attribute defined on the root SVG element, the SVG doesn't change size with the added `viewBox` attribute. The `viewBox` is set to `0 0 ${width} ${height}`, to correctly set the ratio/proportions when scaling the element. The attribute `preserveAspectRatio` is related to the `viewBox` attribute, however I decided it didn't need to be defined in generated SVGs as the default behaviour (scale to fit) is what is desired.

In short, the change doesn't modify the default block appearance. However it enables creators to proportionally resize blocks for different usages.

**Reasoning**
We have been using inline Scratch 2 blocks with no issues, as they have minimal padding around the text of the block. However Scratch 3 blocks have much more padding (plus extra padding from #296) therefore the blocks break apart the lines, even though the text size matches the paragraph text:

![image](https://user-images.githubusercontent.com/8001048/119436427-406ffd00-bd70-11eb-8410-ae66eeae2b6a.png)

With this change the image can be sized much more appropriate for inline text:

![image](https://user-images.githubusercontent.com/8001048/119436303-043c9c80-bd70-11eb-8132-5208f6d2e320.png)

The image above has the following CSS applied to the root SVG element:

```css
width: auto;
height: 2.5rem;
```
_(Note: The two images above have fix #301 applied.)_

Using CSS `transform` didn't fix the problem, presumably since the `span` enclosing the `svg` is rendering to the initial size.

![image](https://user-images.githubusercontent.com/8001048/119437207-bfb20080-bd71-11eb-8ee0-61d99a38c4a7.png)

The image above has the following CSS applied to the root SVG element:

```css
transform: scale(0.7);
transform-origin: 0 0;
```

A red and blue border has been added to the `span` and `svg` elements for readability.

**Useful links**
- [`viewBox` attribute - MDN](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/viewBox)
- [How to Scale SVG - CSS-Tricks](https://css-tricks.com/scale-svg/)