### PR TITLE
Avoid `use xlink:href` in SVG

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "scratchblocks",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/scratch2/draw.js
+++ b/scratch2/draw.js
@@ -41,8 +41,6 @@ var SVG = (module.exports = {
       var value = "" + props[key]
       if (directProps[key]) {
         el[key] = value
-      } else if (/^xlink:/.test(key)) {
-        el.setAttributeNS("http://www.w3.org/1999/xlink", key.slice(6), value)
       } else if (props[key] !== null && props.hasOwnProperty(key)) {
         el.setAttributeNS(null, key, value)
       }
@@ -102,7 +100,7 @@ var SVG = (module.exports = {
 
   symbol(href) {
     return SVG.el("use", {
-      "xlink:href": href,
+      href: href,
     })
   },
 

--- a/scratch3/draw.js
+++ b/scratch3/draw.js
@@ -41,8 +41,6 @@ var SVG = (module.exports = {
       var value = "" + props[key]
       if (directProps[key]) {
         el[key] = value
-      } else if (/^xlink:/.test(key)) {
-        el.setAttributeNS("http://www.w3.org/1999/xlink", key.slice(6), value)
       } else if (props[key] !== null && props.hasOwnProperty(key)) {
         el.setAttributeNS(null, key, value)
       }
@@ -102,7 +100,7 @@ var SVG = (module.exports = {
 
   symbol(href) {
     return SVG.el("use", {
-      "xlink:href": href,
+      href: href,
     })
   },
 


### PR DESCRIPTION
Fixes #348.

Currently if we export an SVG, the `use` elements become the following:

```html
<use xmlns:ns1="http://www.w3.org/1999/xlink" ns1:href="#sb3-greenFlag" ... />
```

This apparently causes a problem with Discourse and/or its virtual DOM.

This commit instead omits `xlink:href` and simply sets `href`.

MDN recommends this; they explicitly recommend against `xlink:href`. And
`<use href>` seems to be supported in all the browsers we care about,
including IE.
