### PR TITLE
Adding a scale option

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Make sure this appears at the end of the page (just before the closing `</body>`
 scratchblocks.renderMatching('pre.blocks', {
   style:     'scratch3',   // Optional, defaults to 'scratch2'.
   languages: ['en', 'de'], // Optional, defaults to ['en'].
+  scale: 1,                // Optional, defaults to 1
 });
 </script>
 ```

--- a/index.html
+++ b/index.html
@@ -244,7 +244,7 @@ function objUpdated() {
       link.textContent = "Export PNG";
       link.className = 'export-link';
       document.body.appendChild(link);
-    }, 2);
+    }, 1);
   }, 0);
 
   // update language dropdown

--- a/index.html
+++ b/index.html
@@ -13,10 +13,7 @@
 <style>
 #preview > svg {
   display: block;
-}
-#preview > .scratch3 {
-  transform: scale(0.675);
-  transform-origin: 0 0;
+  margin-bottom: 20px;
 }
 #preview:before {
   position: relative;
@@ -216,9 +213,11 @@ function objUpdated() {
   console.log(scratchblocks.stringify(doc));
   var docView3 = scratchblocks.newView(doc, {
     style: "scratch3",
+    scale: 0.675
   });
   var docView2 = scratchblocks.newView(doc, {
     style: "scratch2",
+    scale: 1
   });
   var svg3 = docView3.render();
   var svg2 = docView2.render();

--- a/index.js
+++ b/index.js
@@ -55,9 +55,9 @@ module.exports = function(window) {
     )
     switch (options.style) {
       case "scratch2":
-        return scratch2.newView(doc)
+        return scratch2.newView(doc, options)
       case "scratch3":
-        return scratch3.newView(doc)
+        return scratch3.newView(doc, options)
       default:
         throw new Error("Unknown style: " + options.style)
     }
@@ -127,9 +127,11 @@ module.exports = function(window) {
     var selector = selector || "pre.blocks"
     var options = Object.assign(
       {
+        // Default values for the options
         style: "scratch2",
         inline: false,
         languages: ["en"],
+        scale: 1,
 
         read: readCode, // function(el, options) => code
         parse: parse, // function(code, options) => doc

--- a/scratch2/blocks.js
+++ b/scratch2/blocks.js
@@ -679,19 +679,19 @@ DocumentView.prototype.exportSVG = function() {
   return "data:image/svg+xml;utf8," + xml.replace(/[#]/g, encodeURIComponent)
 }
 
-DocumentView.prototype.toCanvas = function(cb, scale) {
-  scale = scale || 1.0
+DocumentView.prototype.toCanvas = function(cb, exportScale) {
+  exportScale = exportScale || 1.0
 
   var canvas = SVG.makeCanvas()
-  canvas.width = this.width * scale
-  canvas.height = this.height * scale
+  canvas.width = this.width * exportScale * this.scale
+  canvas.height = this.height * exportScale * this.scale
   var context = canvas.getContext("2d")
 
   var image = new Image()
   image.src = this.exportSVG()
   image.onload = function() {
     context.save()
-    context.scale(scale, scale)
+    context.scale(exportScale, exportScale)
     context.drawImage(image, 0, 0)
     context.restore()
 

--- a/scratch2/blocks.js
+++ b/scratch2/blocks.js
@@ -601,7 +601,7 @@ ScriptView.prototype.draw = function(inside) {
 
 /* Document */
 
-var DocumentView = function(doc) {
+var DocumentView = function(doc, options) {
   Object.assign(this, doc)
   this.scripts = doc.scripts.map(newView)
 
@@ -609,6 +609,7 @@ var DocumentView = function(doc) {
   this.height = null
   this.el = null
   this.defs = null
+  this.scale = options.scale
 }
 
 DocumentView.prototype.measure = function() {
@@ -642,7 +643,7 @@ DocumentView.prototype.render = function(cb) {
   this.height = height
 
   // return SVG
-  var svg = SVG.newSVG(width, height)
+  var svg = SVG.newSVG(width, height, this.scale)
   svg.appendChild(
     (this.defs = SVG.withChildren(
       SVG.el("defs"),
@@ -735,7 +736,7 @@ const viewFor = node => {
   }
 }
 
-const newView = node => new (viewFor(node))(node)
+const newView = (node, options) => new (viewFor(node))(node, options)
 
 module.exports = {
   newView,

--- a/scratch2/draw.js
+++ b/scratch2/draw.js
@@ -59,11 +59,11 @@ var SVG = (module.exports = {
     return SVG.withChildren(SVG.el("g"), children)
   },
 
-  newSVG(width, height) {
+  newSVG(width, height, scale) {
     return SVG.el("svg", {
       version: "1.1",
-      width: width,
-      height: height,
+      width: width * scale,
+      height: height * scale,
       viewBox: `0 0 ${width} ${height}`,
     })
   },

--- a/scratch3/blocks.js
+++ b/scratch3/blocks.js
@@ -707,7 +707,7 @@ ScriptView.prototype.draw = function(inside) {
 
 /* Document */
 
-var DocumentView = function(doc) {
+var DocumentView = function(doc, options) {
   Object.assign(this, doc)
   this.scripts = doc.scripts.map(newView)
 
@@ -715,6 +715,7 @@ var DocumentView = function(doc) {
   this.height = null
   this.el = null
   this.defs = null
+  this.scale = options.scale
 }
 
 DocumentView.prototype.measure = function() {
@@ -749,7 +750,7 @@ DocumentView.prototype.render = function(cb) {
   this.height = height
 
   // return SVG
-  var svg = SVG.newSVG(width, height)
+  var svg = SVG.newSVG(width, height, this.scale)
   svg.appendChild((this.defs = SVG.withChildren(SVG.el("defs"), makeIcons())))
 
   svg.appendChild(SVG.group(elements))
@@ -833,7 +834,7 @@ const viewFor = node => {
   }
 }
 
-const newView = node => new (viewFor(node))(node)
+const newView = (node, options) => new (viewFor(node))(node, options)
 
 module.exports = {
   newView,

--- a/scratch3/blocks.js
+++ b/scratch3/blocks.js
@@ -777,19 +777,19 @@ DocumentView.prototype.exportSVG = function() {
   return "data:image/svg+xml;utf8," + xml.replace(/[#]/g, encodeURIComponent)
 }
 
-DocumentView.prototype.toCanvas = function(cb, scale) {
-  scale = scale || 1.0
+DocumentView.prototype.toCanvas = function(cb, exportScale) {
+  exportScale = exportScale || 1.0
 
   var canvas = SVG.makeCanvas()
-  canvas.width = this.width * scale
-  canvas.height = this.height * scale
+  canvas.width = this.width * exportScale * this.scale
+  canvas.height = this.height * exportScale * this.scale
   var context = canvas.getContext("2d")
 
   var image = new Image()
   image.src = this.exportSVG()
   image.onload = function() {
     context.save()
-    context.scale(scale, scale)
+    context.scale(exportScale, exportScale)
     context.drawImage(image, 0, 0)
     context.restore()
 

--- a/scratch3/draw.js
+++ b/scratch3/draw.js
@@ -59,11 +59,11 @@ var SVG = (module.exports = {
     return SVG.withChildren(SVG.el("g"), children)
   },
 
-  newSVG(width, height) {
+  newSVG(width, height, scale) {
     return SVG.el("svg", {
       version: "1.1",
-      width: width,
-      height: height,
+      width: width * scale,
+      height: height * scale,
       viewBox: `0 0 ${width} ${height}`,
     })
   },

--- a/snapshots/client.js
+++ b/snapshots/client.js
@@ -11,7 +11,7 @@ window.render = function(source, options, scale) {
 
   var view = scratchblocks.newView(doc, {
     style: options.style,
-    scale: options.scale
+    scale: options.scale,
   })
   var svg = view.render()
 

--- a/snapshots/client.js
+++ b/snapshots/client.js
@@ -11,6 +11,7 @@ window.render = function(source, options, scale) {
 
   var view = scratchblocks.newView(doc, {
     style: options.style,
+    scale: options.scale
   })
   var svg = view.render()
 


### PR DESCRIPTION
The scale option can resize the SVG. By default it is 1

- Mentioned in README
- Tests still run
- Seems to work with both Scratch 2 and 3 style

Two things I'm not sure of 
- What is the `client.js` file and if it should be modified 
- Did it / should it affect the image export features?

```js
scratchblocks.renderMatching('pre.blocks', {
  style:     'scratch3',   // Optional, defaults to 'scratch2'.
  languages: ['en', 'de'], // Optional, defaults to ['en'].
  scale: 1,                // Optional, defaults to 1
});
```