### PR TITLE
Don't crop puzzle piece from trailing C blocks

### DIFF
--- a/syntax/model.js
+++ b/syntax/model.js
@@ -139,7 +139,7 @@ var Block = function(info, children, comment) {
 
   var shape = this.info.shape
   this.isHat = shape === "hat" || shape === "cat" || shape === "define-hat"
-  this.hasPuzzle = shape === "stack" || shape === "hat" || shape === "cat"
+  this.hasPuzzle = shape === "stack" || shape === "hat" || shape === "cat" || shape === "c-block"
   this.isFinal = /cap/.test(shape)
   this.isCommand = shape === "stack" || shape === "cap" || /block/.test(shape)
   this.isOutline = shape === "outline"


### PR DESCRIPTION
If a c-block was the last thing in a script, its bottom puzzle piece would get chopped off.

I believe this is because the test for `hasPuzzle` was wrong.

While this code is shared between both the `scratch2` and `scratch3` renderers, it doesn't seem to affect the Scratch 2.0 renderer. In fact, this flag is only used in exactly one place: in the Scratch 3 `ScriptView` renderer!

Fixes #380.