### PR TITLE
scratch3: Allow empty loops

### DIFF
--- a/scratch3/blocks.js
+++ b/scratch3/blocks.js
@@ -462,14 +462,16 @@ BlockView.prototype.draw = function() {
       }
 
       // Align first input with right of notch
-      var cmw = 48 - this.horizontalPadding(children[0])
-      if (
-        (this.isCommand || this.isOutline) &&
-        !child.isLabel &&
-        !child.isIcon &&
-        line.width < cmw
-      ) {
-        line.width = cmw
+      if (children[0] != null) {
+        var cmw = 48 - this.horizontalPadding(children[0])
+        if (
+          (this.isCommand || this.isOutline) &&
+          !child.isLabel &&
+          !child.isIcon &&
+          line.width < cmw
+        ) {
+          line.width = cmw
+        }
       }
 
       // Align extension category icons below notch


### PR DESCRIPTION
The code for aligning the first input was calling `children[0]`, which of course fails if there are no children.

Fixes #346.

Thanks to @apple502j and @Kenny2github for diagnosing!