### PR TITLE
syntax: Make comparator predicate detection more specific

### DIFF
--- a/syntax/syntax.js
+++ b/syntax/syntax.js
@@ -237,14 +237,18 @@ function parseLines(code, languages) {
     var children = []
     var label
     while (tok && tok !== "\n") {
-      if (tok === "<" || (tok === ">" && end === ">")) {
-        var last = children[children.length - 1]
+      // So that comparison operators `<()<()>` and `<()>()>` don't need the
+      // central <> escaped, we interpret it as a label if particular
+      // conditions are met.
+      if (
+        (tok === "<" || tok === ">") &&
+        end === ">" && // We're parsing a predicate.
+        children.length === 1 && // There's exactly one AST node behind us.
+        !children[children.length - 1].isLabel // That node is not a label.
+      ) {
         var c = peekNonWs()
-        if (
-          last &&
-          !last.isLabel &&
-          (c === "[" || c === "(" || c === "<" || c === "{")
-        ) {
+        // The next token starts some kind of input.
+        if (c === "[" || c === "(" || c === "<" || c === "{") {
           label = null
           children.push(new Label(tok))
           next()

--- a/tests/syntax.test.js
+++ b/tests/syntax.test.js
@@ -515,7 +515,10 @@ describe('comparison ops: < and > ', () => {
     expect(parseBlock('<<>><>>').info.selector).toBe('>')
   })
 
-  // TODO add that test case from that issue
+  test('regression for #399', () => {
+    expect(parseBlock('join (1) <(1)=(1)>').children.length).toBe(3)
+    expect(parseBlock('go [forward v] <(1) = (1)> layers').children.length).toBe(4)
+  })
 })
 
 // Test that blocks renamed between Scratch 2 and Scratch 3 work in either form.


### PR DESCRIPTION
Fixes #399.

We have a special rule in the parser that detects the comparison predicates `<()>()>` and `<()<()>` and makes sure the central <> is parsed as a label, rather than the start or end of a predicate.

This rule was triggering in a bunch of situations we didn't want. This
change makes it more specific, so that it should be (almost) impossible
to trigger when we don't want.