### PR TITLE
Make Catalan alias consistent

### DIFF
--- a/locales-src/extra_aliases.js
+++ b/locales-src/extra_aliases.js
@@ -118,6 +118,7 @@ module.exports = {
     "gira a l'esquerra %1 graus": "MOTION_TURNLEFT",
     "gira a la dreta %1 graus": "MOTION_TURNRIGHT",
     "quan la bandera verda es cliqui": "EVENT_WHENFLAGCLICKED",
+    "quan la bandera verda es premi": "EVENT_WHENFLAGCLICKED",
     fi: "scratchblocks:end",
   },
 

--- a/locales-src/extra_aliases.js
+++ b/locales-src/extra_aliases.js
@@ -117,7 +117,7 @@ module.exports = {
     // Catalan
     "gira a l'esquerra %1 graus": "MOTION_TURNLEFT",
     "gira a la dreta %1 graus": "MOTION_TURNRIGHT",
-    "quan la bandera verda es premi": "EVENT_WHENFLAGCLICKED",
+    "quan la bandera verda es cliqui": "EVENT_WHENFLAGCLICKED",
     fi: "scratchblocks:end",
   },
 

--- a/locales/ca.json
+++ b/locales/ca.json
@@ -258,7 +258,7 @@
   "aliases": {
     "gira a l'esquerra %1 graus": "MOTION_TURNLEFT",
     "gira a la dreta %1 graus": "MOTION_TURNRIGHT",
-    "quan la bandera verda es premi": "EVENT_WHENFLAGCLICKED",
+    "quan la bandera verda es cliqui": "EVENT_WHENFLAGCLICKED",
     "fi": "scratchblocks:end"
   },
   "name": "Català",

--- a/locales/ca.json
+++ b/locales/ca.json
@@ -259,6 +259,7 @@
     "gira a l'esquerra %1 graus": "MOTION_TURNLEFT",
     "gira a la dreta %1 graus": "MOTION_TURNRIGHT",
     "quan la bandera verda es cliqui": "EVENT_WHENFLAGCLICKED",
+    "quan la bandera verda es premi": "EVENT_WHENFLAGCLICKED",
     "fi": "scratchblocks:end"
   },
   "name": "Català",


### PR DESCRIPTION
The Catalan alias for the "when green flag clicked" was inconsistent with the original translation (it used the word "[premi](https://github.com/scratchblocks/scratchblocks/blob/537691ef82c19f07a37bf8f85b310fd87d4c8800/locales/ca.json#L261)" instead of "[cliqui](https://github.com/scratchblocks/scratchblocks/blob/537691ef82c19f07a37bf8f85b310fd87d4c8800/locales/ca.json#L62)"). This pull request makes it consistent.