### PR TITLE
syntax: Migrate to classes

### DIFF
--- a/syntax/model.js
+++ b/syntax/model.js
@@ -39,340 +39,342 @@ import {
   blockName,
 } from "./blocks.js"
 
-/* Label */
+export class Label {
+  constructor(value, cls) {
+    this.value = value
+    this.cls = cls || ""
+    this.el = null
+    this.height = 12
+    this.metrics = null
+    this.x = 0
+  }
 
-export var Label = function (value, cls) {
-  this.value = value
-  this.cls = cls || ""
-  this.el = null
-  this.height = 12
-  this.metrics = null
-  this.x = 0
+  stringify() {
+    if (this.value === "<" || this.value === ">") return this.value
+    return this.value.replace(/([<>[\](){}])/g, "\\$1")
+  }
 }
 Label.prototype.isLabel = true
 
-Label.prototype.stringify = function () {
-  if (this.value === "<" || this.value === ">") return this.value
-  return this.value.replace(/([<>[\](){}])/g, "\\$1")
-}
+export class Icon {
+  constructor(name) {
+    this.name = name
+    this.isArrow = name === "loopArrow"
 
-/* Icon */
+    assert(Icon.icons[name], "no info for icon " + name)
+  }
 
-export var Icon = function (name) {
-  this.name = name
-  this.isArrow = name === "loopArrow"
+  static icons = {
+    greenFlag: true,
+    stopSign: true,
+    turnLeft: true,
+    turnRight: true,
+    loopArrow: true,
+    addInput: true,
+    delInput: true,
+    list: true,
+  }
 
-  assert(Icon.icons[name], "no info for icon " + name)
+  stringify() {
+    return unicodeIcons["@" + this.name] || ""
+  }
 }
 Icon.prototype.isIcon = true
 
-Icon.icons = {
-  greenFlag: true,
-  stopSign: true,
-  turnLeft: true,
-  turnRight: true,
-  loopArrow: true,
-  addInput: true,
-  delInput: true,
-  list: true,
-}
+export class Input {
+  constructor(shape, value, menu) {
+    this.shape = shape
+    this.value = value
+    this.menu = menu || null
 
-Icon.prototype.stringify = function () {
-  return unicodeIcons["@" + this.name] || ""
-}
+    this.isRound = shape === "number" || shape === "number-dropdown"
+    this.isBoolean = shape === "boolean"
+    this.isStack = shape === "stack"
+    this.isInset =
+      shape === "boolean" || shape === "stack" || shape === "reporter"
+    this.isColor = shape === "color"
+    this.hasArrow = shape === "dropdown" || shape === "number-dropdown"
+    this.isDarker =
+      shape === "boolean" || shape === "stack" || shape === "dropdown"
+    this.isSquare =
+      shape === "string" || shape === "color" || shape === "dropdown"
 
-/* Input */
+    this.hasLabel = !(this.isColor || this.isInset)
+    this.label = this.hasLabel
+      ? new Label(value, "literal-" + this.shape)
+      : null
+    this.x = 0
+  }
 
-export var Input = function (shape, value, menu) {
-  this.shape = shape
-  this.value = value
-  this.menu = menu || null
+  stringify() {
+    if (this.isColor) {
+      assert(this.value[0] === "#")
+      return "[" + this.value + "]"
+    }
+    var text = (this.value ? "" + this.value : "")
+      .replace(/ v$/, " \\v")
+      .replace(/([\]\\])/g, "\\$1")
+    if (this.hasArrow) text += " v"
+    return this.isRound
+      ? "(" + text + ")"
+      : this.isSquare
+      ? "[" + text + "]"
+      : this.isBoolean
+      ? "<>"
+      : this.isStack
+      ? "{}"
+      : text
+  }
 
-  this.isRound = shape === "number" || shape === "number-dropdown"
-  this.isBoolean = shape === "boolean"
-  this.isStack = shape === "stack"
-  this.isInset =
-    shape === "boolean" || shape === "stack" || shape === "reporter"
-  this.isColor = shape === "color"
-  this.hasArrow = shape === "dropdown" || shape === "number-dropdown"
-  this.isDarker =
-    shape === "boolean" || shape === "stack" || shape === "dropdown"
-  this.isSquare =
-    shape === "string" || shape === "color" || shape === "dropdown"
-
-  this.hasLabel = !(this.isColor || this.isInset)
-  this.label = this.hasLabel ? new Label(value, "literal-" + this.shape) : null
-  this.x = 0
+  translate(lang) {
+    if (this.hasArrow) {
+      var value = this.menu || this.value
+      this.value = value // TODO translate dropdown value
+      this.label = new Label(this.value, "literal-" + this.shape)
+    }
+  }
 }
 Input.prototype.isInput = true
 
-Input.prototype.stringify = function () {
-  if (this.isColor) {
-    assert(this.value[0] === "#")
-    return "[" + this.value + "]"
+export class Block {
+  constructor(info, children, comment) {
+    assert(info)
+    this.info = Object.assign({}, info)
+    this.children = children
+    this.comment = comment || null
+    this.diff = null
+
+    var shape = this.info.shape
+    this.isHat = shape === "hat" || shape === "cat" || shape === "define-hat"
+    this.hasPuzzle =
+      shape === "stack" ||
+      shape === "hat" ||
+      shape === "cat" ||
+      shape === "c-block"
+    this.isFinal = /cap/.test(shape)
+    this.isCommand = shape === "stack" || shape === "cap" || /block/.test(shape)
+    this.isOutline = shape === "outline"
+    this.isReporter = shape === "reporter"
+    this.isBoolean = shape === "boolean"
+
+    this.isRing = shape === "ring"
+    this.hasScript = /block/.test(shape)
+    this.isElse = shape === "celse"
+    this.isEnd = shape === "cend"
   }
-  var text = (this.value ? "" + this.value : "")
-    .replace(/ v$/, " \\v")
-    .replace(/([\]\\])/g, "\\$1")
-  if (this.hasArrow) text += " v"
-  return this.isRound
-    ? "(" + text + ")"
-    : this.isSquare
-    ? "[" + text + "]"
-    : this.isBoolean
-    ? "<>"
-    : this.isStack
-    ? "{}"
-    : text
-}
 
-Input.prototype.translate = function (lang) {
-  if (this.hasArrow) {
-    var value = this.menu || this.value
-    this.value = value // TODO translate dropdown value
-    this.label = new Label(this.value, "literal-" + this.shape)
+  stringify(extras) {
+    var firstInput = null
+    var checkAlias = false
+    var text = this.children
+      .map(function (child) {
+        if (child.isIcon) checkAlias = true
+        if (!firstInput && !(child.isLabel || child.isIcon)) firstInput = child
+        return child.isScript
+          ? "\n" + indent(child.stringify()) + "\n"
+          : child.stringify().trim() + " "
+      })
+      .join("")
+      .trim()
+
+    var lang = this.info.language
+    if (checkAlias && lang && this.info.selector) {
+      var type = blocksById[this.info.id]
+      var spec = type.spec
+      var aliases = lang.nativeAliases[this.info.id]
+      if (aliases && aliases.length) {
+        var alias = aliases[0]
+        // TODO make translate() not in-place, and use that
+        if (inputPat.test(alias) && firstInput) {
+          alias = alias.replace(inputPat, firstInput.stringify())
+        }
+        return alias
+      }
+    }
+
+    var overrides = extras || ""
+    if (
+      this.info.categoryIsDefault === false ||
+      (this.info.category === "custom-arg" &&
+        (this.isReporter || this.isBoolean)) ||
+      (this.info.category === "custom" && this.info.shape === "stack")
+    ) {
+      if (overrides) overrides += " "
+      overrides += this.info.category
+    }
+    if (overrides) {
+      text += " :: " + overrides
+    }
+    return this.hasScript
+      ? text + "\nend"
+      : this.info.shape === "reporter"
+      ? "(" + text + ")"
+      : this.info.shape === "boolean"
+      ? "<" + text + ">"
+      : text
   }
-}
 
-/* Block */
+  translate(lang, isShallow) {
+    if (!lang) throw new Error("Missing language")
 
-export var Block = function (info, children, comment) {
-  assert(info)
-  this.info = Object.assign({}, info)
-  this.children = children
-  this.comment = comment || null
-  this.diff = null
+    var id = this.info.id
+    if (!id) return
 
-  var shape = this.info.shape
-  this.isHat = shape === "hat" || shape === "cat" || shape === "define-hat"
-  this.hasPuzzle =
-    shape === "stack" ||
-    shape === "hat" ||
-    shape === "cat" ||
-    shape === "c-block"
-  this.isFinal = /cap/.test(shape)
-  this.isCommand = shape === "stack" || shape === "cap" || /block/.test(shape)
-  this.isOutline = shape === "outline"
-  this.isReporter = shape === "reporter"
-  this.isBoolean = shape === "boolean"
+    if (id === "PROCEDURES_DEFINITION") {
+      // Find the first 'outline' child (there should be exactly one).
+      const outline = this.children.find(child => child.isOutline)
 
-  this.isRing = shape === "ring"
-  this.hasScript = /block/.test(shape)
-  this.isElse = shape === "celse"
-  this.isEnd = shape === "cend"
+      this.children = []
+      for (const word of lang.definePrefix) {
+        this.children.push(new Label(word))
+      }
+      this.children.push(outline)
+      for (const word of lang.defineSuffix) {
+        this.children.push(new Label(word))
+      }
+      return
+    }
+
+    var type = blocksById[id]
+    var oldSpec = this.info.language.commands[id]
+
+    var nativeSpec = lang.commands[id]
+    if (!nativeSpec) return
+    var nativeInfo = parseSpec(nativeSpec)
+
+    var rawArgs = this.children.filter(function (child) {
+      return !child.isLabel && !child.isIcon
+    })
+
+    if (!isShallow) {
+      rawArgs.forEach(function (child) {
+        child.translate(lang)
+      })
+    }
+
+    // Work out indexes of existing children
+    var oldParts = parseSpec(oldSpec).parts
+    var oldInputOrder = oldParts
+      .map(part => parseInputNumber(part))
+      .filter(x => !!x)
+
+    var highestNumber = 0
+    var args = oldInputOrder.map(number => {
+      highestNumber = Math.max(highestNumber, number)
+      return rawArgs[number - 1]
+    })
+    var remainingArgs = rawArgs.slice(highestNumber)
+
+    // Get new children by index
+    this.children = nativeInfo.parts
+      .map(function (part) {
+        var part = part.trim()
+        if (!part) return
+        var number = parseInputNumber(part)
+        if (number) {
+          return args[number - 1]
+        } else {
+          return iconPat.test(part) ? new Icon(part.slice(1)) : new Label(part)
+        }
+      })
+      .filter(x => !!x)
+
+    // Push any remaining children, so we pick up C block bodies
+    remainingArgs.forEach((arg, index) => {
+      if (index === 1 && this.info.id === "CONTROL_IF") {
+        this.children.push(new Label(lang.commands["CONTROL_ELSE"]))
+      }
+      this.children.push(arg)
+    })
+
+    this.info.language = lang
+    this.info.isRTL = rtlLanguages.indexOf(lang.code) > -1
+    this.info.categoryIsDefault = true
+  }
 }
 Block.prototype.isBlock = true
 
-Block.prototype.stringify = function (extras) {
-  var firstInput = null
-  var checkAlias = false
-  var text = this.children
-    .map(function (child) {
-      if (child.isIcon) checkAlias = true
-      if (!firstInput && !(child.isLabel || child.isIcon)) firstInput = child
-      return child.isScript
-        ? "\n" + indent(child.stringify()) + "\n"
-        : child.stringify().trim() + " "
-    })
-    .join("")
-    .trim()
-
-  var lang = this.info.language
-  if (checkAlias && lang && this.info.selector) {
-    var type = blocksById[this.info.id]
-    var spec = type.spec
-    var aliases = lang.nativeAliases[this.info.id]
-    if (aliases && aliases.length) {
-      var alias = aliases[0]
-      // TODO make translate() not in-place, and use that
-      if (inputPat.test(alias) && firstInput) {
-        alias = alias.replace(inputPat, firstInput.stringify())
-      }
-      return alias
-    }
+export class Comment {
+  constructor(value, hasBlock) {
+    this.label = new Label(value, "comment-label")
+    this.width = null
+    this.hasBlock = hasBlock
   }
 
-  var overrides = extras || ""
-  if (
-    this.info.categoryIsDefault === false ||
-    (this.info.category === "custom-arg" &&
-      (this.isReporter || this.isBoolean)) ||
-    (this.info.category === "custom" && this.info.shape === "stack")
-  ) {
-    if (overrides) overrides += " "
-    overrides += this.info.category
+  stringify() {
+    return "// " + this.label.value
   }
-  if (overrides) {
-    text += " :: " + overrides
-  }
-  return this.hasScript
-    ? text + "\nend"
-    : this.info.shape === "reporter"
-    ? "(" + text + ")"
-    : this.info.shape === "boolean"
-    ? "<" + text + ">"
-    : text
-}
-
-Block.prototype.translate = function (lang, isShallow) {
-  if (!lang) throw new Error("Missing language")
-
-  var id = this.info.id
-  if (!id) return
-
-  if (id === "PROCEDURES_DEFINITION") {
-    // Find the first 'outline' child (there should be exactly one).
-    const outline = this.children.find(child => child.isOutline)
-
-    this.children = []
-    for (const word of lang.definePrefix) {
-      this.children.push(new Label(word))
-    }
-    this.children.push(outline)
-    for (const word of lang.defineSuffix) {
-      this.children.push(new Label(word))
-    }
-    return
-  }
-
-  var type = blocksById[id]
-  var oldSpec = this.info.language.commands[id]
-
-  var nativeSpec = lang.commands[id]
-  if (!nativeSpec) return
-  var nativeInfo = parseSpec(nativeSpec)
-
-  var rawArgs = this.children.filter(function (child) {
-    return !child.isLabel && !child.isIcon
-  })
-
-  if (!isShallow) {
-    rawArgs.forEach(function (child) {
-      child.translate(lang)
-    })
-  }
-
-  // Work out indexes of existing children
-  var oldParts = parseSpec(oldSpec).parts
-  var oldInputOrder = oldParts
-    .map(part => parseInputNumber(part))
-    .filter(x => !!x)
-
-  var highestNumber = 0
-  var args = oldInputOrder.map(number => {
-    highestNumber = Math.max(highestNumber, number)
-    return rawArgs[number - 1]
-  })
-  var remainingArgs = rawArgs.slice(highestNumber)
-
-  // Get new children by index
-  this.children = nativeInfo.parts
-    .map(function (part) {
-      var part = part.trim()
-      if (!part) return
-      var number = parseInputNumber(part)
-      if (number) {
-        return args[number - 1]
-      } else {
-        return iconPat.test(part) ? new Icon(part.slice(1)) : new Label(part)
-      }
-    })
-    .filter(x => !!x)
-
-  // Push any remaining children, so we pick up C block bodies
-  remainingArgs.forEach((arg, index) => {
-    if (index === 1 && this.info.id === "CONTROL_IF") {
-      this.children.push(new Label(lang.commands["CONTROL_ELSE"]))
-    }
-    this.children.push(arg)
-  })
-
-  this.info.language = lang
-  this.info.isRTL = rtlLanguages.indexOf(lang.code) > -1
-  this.info.categoryIsDefault = true
-}
-
-/* Comment */
-
-export var Comment = function (value, hasBlock) {
-  this.label = new Label(value, "comment-label")
-  this.width = null
-  this.hasBlock = hasBlock
 }
 Comment.prototype.isComment = true
 
-Comment.prototype.stringify = function () {
-  return "// " + this.label.value
-}
+export class Glow {
+  constructor(child) {
+    assert(child)
+    this.child = child
+    if (child.isBlock) {
+      this.shape = child.info.shape
+      this.info = child.info
+    } else {
+      this.shape = "stack"
+    }
+  }
 
-/* Glow */
+  stringify() {
+    if (this.child.isBlock) {
+      return this.child.stringify("+")
+    } else {
+      var lines = this.child.stringify().split("\n")
+      return lines.map(line => "+ " + line).join("\n")
+    }
+  }
 
-export var Glow = function (child) {
-  assert(child)
-  this.child = child
-  if (child.isBlock) {
-    this.shape = child.info.shape
-    this.info = child.info
-  } else {
-    this.shape = "stack"
+  translate(lang) {
+    this.child.translate(lang)
   }
 }
 Glow.prototype.isGlow = true
 
-Glow.prototype.stringify = function () {
-  if (this.child.isBlock) {
-    return this.child.stringify("+")
-  } else {
-    var lines = this.child.stringify().split("\n")
-    return lines.map(line => "+ " + line).join("\n")
+export class Script {
+  constructor(blocks) {
+    this.blocks = blocks
+    this.isEmpty = !blocks.length
+    this.isFinal = !this.isEmpty && blocks[blocks.length - 1].isFinal
   }
-}
 
-Glow.prototype.translate = function (lang) {
-  this.child.translate(lang)
-}
+  stringify() {
+    return this.blocks
+      .map(function (block) {
+        var line = block.stringify()
+        if (block.comment) line += " " + block.comment.stringify()
+        return line
+      })
+      .join("\n")
+  }
 
-/* Script */
-
-export var Script = function (blocks) {
-  this.blocks = blocks
-  this.isEmpty = !blocks.length
-  this.isFinal = !this.isEmpty && blocks[blocks.length - 1].isFinal
+  translate(lang) {
+    this.blocks.forEach(function (block) {
+      block.translate(lang)
+    })
+  }
 }
 Script.prototype.isScript = true
 
-Script.prototype.stringify = function () {
-  return this.blocks
-    .map(function (block) {
-      var line = block.stringify()
-      if (block.comment) line += " " + block.comment.stringify()
-      return line
+export class Document {
+  constructor(scripts) {
+    this.scripts = scripts
+  }
+
+  stringify() {
+    return this.scripts
+      .map(function (script) {
+        return script.stringify()
+      })
+      .join("\n\n")
+  }
+
+  translate(lang) {
+    this.scripts.forEach(function (script) {
+      script.translate(lang)
     })
-    .join("\n")
-}
-
-Script.prototype.translate = function (lang) {
-  this.blocks.forEach(function (block) {
-    block.translate(lang)
-  })
-}
-
-/* Document */
-
-export var Document = function (scripts) {
-  this.scripts = scripts
-}
-
-Document.prototype.stringify = function () {
-  return this.scripts
-    .map(function (script) {
-      return script.stringify()
-    })
-    .join("\n\n")
-}
-
-Document.prototype.translate = function (lang) {
-  this.scripts.forEach(function (script) {
-    script.translate(lang)
-  })
+  }
 }

--- a/syntax/model.js
+++ b/syntax/model.js
@@ -48,13 +48,13 @@ export class Label {
     this.metrics = null
     this.x = 0
   }
+  isLabel = true
 
   stringify() {
     if (this.value === "<" || this.value === ">") return this.value
     return this.value.replace(/([<>[\](){}])/g, "\\$1")
   }
 }
-Label.prototype.isLabel = true
 
 export class Icon {
   constructor(name) {
@@ -63,6 +63,7 @@ export class Icon {
 
     assert(Icon.icons[name], "no info for icon " + name)
   }
+  isIcon = true
 
   static icons = {
     greenFlag: true,
@@ -79,7 +80,6 @@ export class Icon {
     return unicodeIcons["@" + this.name] || ""
   }
 }
-Icon.prototype.isIcon = true
 
 export class Input {
   constructor(shape, value, menu) {
@@ -105,6 +105,7 @@ export class Input {
       : null
     this.x = 0
   }
+  isInput = true
 
   stringify() {
     if (this.isColor) {
@@ -134,7 +135,6 @@ export class Input {
     }
   }
 }
-Input.prototype.isInput = true
 
 export class Block {
   constructor(info, children, comment) {
@@ -162,6 +162,7 @@ export class Block {
     this.isElse = shape === "celse"
     this.isEnd = shape === "cend"
   }
+  isBlock = true
 
   stringify(extras) {
     var firstInput = null
@@ -292,7 +293,6 @@ export class Block {
     this.info.categoryIsDefault = true
   }
 }
-Block.prototype.isBlock = true
 
 export class Comment {
   constructor(value, hasBlock) {
@@ -300,12 +300,12 @@ export class Comment {
     this.width = null
     this.hasBlock = hasBlock
   }
+  isComment = true
 
   stringify() {
     return "// " + this.label.value
   }
 }
-Comment.prototype.isComment = true
 
 export class Glow {
   constructor(child) {
@@ -318,6 +318,7 @@ export class Glow {
       this.shape = "stack"
     }
   }
+  isGlow = true
 
   stringify() {
     if (this.child.isBlock) {
@@ -332,7 +333,6 @@ export class Glow {
     this.child.translate(lang)
   }
 }
-Glow.prototype.isGlow = true
 
 export class Script {
   constructor(blocks) {
@@ -340,6 +340,7 @@ export class Script {
     this.isEmpty = !blocks.length
     this.isFinal = !this.isEmpty && blocks[blocks.length - 1].isFinal
   }
+  isScript = true
 
   stringify() {
     return this.blocks
@@ -357,7 +358,6 @@ export class Script {
     })
   }
 }
-Script.prototype.isScript = true
 
 export class Document {
   constructor(scripts) {


### PR DESCRIPTION
This PR makes a start on the classes part of #413  by migrating the `syntax` package to use ES6 class syntax.

:information_source: You'll probably want to review [ignoring whitespace](https://github.com/scratchblocks/scratchblocks/pull/420/files?w=1)!