### PR TITLE
Migrate scratch2, scratch3 to class syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,12 +33,11 @@ export default function (window) {
   }
 
   function newView(doc, options) {
-    var options = Object.assign(
-      {
-        style: "scratch2",
-      },
-      options
-    )
+    var options = {
+      style: "scratch2",
+      ...options,
+    }
+
     options.scale = options.scale || 1
     switch (options.style) {
       case "scratch2":
@@ -65,12 +64,10 @@ export default function (window) {
 
   // read code from a DOM element
   function readCode(el, options) {
-    var options = Object.assign(
-      {
-        inline: false,
-      },
-      options
-    )
+    var options = {
+      inline: false,
+      ...options,
+    }
 
     var html = el.innerHTML.replace(/<br>\s?|\n|\r\n|\r/gi, "\n")
     var pre = document.createElement("pre")
@@ -112,21 +109,20 @@ export default function (window) {
    */
   var renderMatching = function (selector, options) {
     var selector = selector || "pre.blocks"
-    var options = Object.assign(
-      {
-        // Default values for the options
-        style: "scratch2",
-        inline: false,
-        languages: ["en"],
-        scale: 1,
+    var options = {
+      // Default values for the options
+      style: "scratch2",
+      inline: false,
+      languages: ["en"],
+      scale: 1,
 
-        read: readCode, // function(el, options) => code
-        parse: parse, // function(code, options) => doc
-        render: render, // function(doc) => svg
-        replace: replace, // function(el, svg, doc, options)
-      },
-      options
-    )
+      read: readCode, // function(el, options) => code
+      parse: parse, // function(code, options) => doc
+      render: render, // function(doc) => svg
+      replace: replace, // function(el, svg, doc, options)
+
+      ...options,
+    }
 
     // find elements
     var results = [].slice.apply(document.querySelectorAll(selector))

--- a/locales-src/build-locales.js
+++ b/locales-src/build-locales.js
@@ -25,10 +25,10 @@ const rawLocales = async () => {
     const raw = {
       code: code,
       mappings: await readJSONFile(
-        `node_modules/scratch-l10n/editor/blocks/${code}.json`
+        `node_modules/scratch-l10n/editor/blocks/${code}.json`,
       ),
       extensionMappings: await readJSONFile(
-        `node_modules/scratch-l10n/editor/extensions/${code}.json`
+        `node_modules/scratch-l10n/editor/extensions/${code}.json`,
       ),
     }
     if (code === "en") {
@@ -191,7 +191,7 @@ const buildLocale = (code, rawLocale) => {
   }
   const frac = commandCount / scratchSpecs.length
   console.log(
-    `${(code + ":").padEnd(8)} ${(frac * 100).toFixed(1).padStart(5)}%`
+    `${(code + ":").padEnd(8)} ${(frac * 100).toFixed(1).padStart(5)}%`,
   )
 
   // Approximate fraction of blocks translated. For some reason not all blocks

--- a/locales-src/rollup-optimized-css-text.js
+++ b/locales-src/rollup-optimized-css-text.js
@@ -15,7 +15,7 @@ export default opts => {
         return Promise.resolve(
           opts.minify
             ? import("csso").then(csso => csso.minify(code).css)
-            : code
+            : code,
         ).then(processed => ({
           code: "export default " + JSON.stringify(processed),
           map: { mappings: "" },

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   "pre-commit": "lint:staged",
   "prettier": {
     "semi": false,
-    "trailingComma": "es5",
+    "trailingComma": "all",
     "arrowParens": "avoid"
   },
   "jest": {

--- a/scratch2/blocks.js
+++ b/scratch2/blocks.js
@@ -143,7 +143,7 @@ class InputView {
       var w = Math.max(
         14,
         this.label.width +
-          (this.shape === "string" || this.shape === "number-dropdown" ? 6 : 9)
+          (this.shape === "string" || this.shape === "number-dropdown" ? 6 : 9),
       )
     } else {
       var w = this.isInset ? 30 : this.isColor ? 13 : null
@@ -186,8 +186,8 @@ class InputView {
             points: [7, 0, 3.5, 4, 0, 0],
             fill: "#000",
             opacity: "0.6",
-          })
-        )
+          }),
+        ),
       )
     }
     return result
@@ -411,7 +411,7 @@ class BlockView {
         ? 83
         : this.isCommand || this.isOutline || this.isRing
         ? 39
-        : 20
+        : 20,
     )
     this.height = y
     this.width = scriptWidth
@@ -663,8 +663,8 @@ class DocumentView {
           bevelFilter("bevelFilter", false),
           bevelFilter("inputBevelFilter", true),
           darkFilter("inputDarkFilter"),
-        ].concat(makeIcons())
-      ))
+        ].concat(makeIcons()),
+      )),
     )
 
     svg.appendChild(SVG.group(elements))

--- a/scratch2/blocks.js
+++ b/scratch2/blocks.js
@@ -33,7 +33,10 @@ export class LabelView {
     this.metrics = null
     this.x = 0
   }
-  isLabel = true
+
+  get isLabel() {
+    return true
+  }
 
   draw() {
     return this.el
@@ -42,9 +45,6 @@ export class LabelView {
   get width() {
     return this.metrics.width
   }
-
-  static metricsCache = {}
-  static toMeasure = []
 
   measure() {
     var value = this.value
@@ -80,6 +80,9 @@ export class LabelView {
   }
 }
 
+LabelView.metricsCache = {}
+LabelView.toMeasure = []
+
 class IconView {
   constructor(icon) {
     Object.assign(this, icon)
@@ -90,7 +93,10 @@ class IconView {
     }
     Object.assign(this, info)
   }
-  isIcon = true
+
+  get isIcon() {
+    return true
+  }
 
   draw() {
     return SVG.symbol("#" + this.name, {
@@ -99,15 +105,17 @@ class IconView {
     })
   }
 
-  static icons = {
-    greenFlag: { width: 20, height: 21, dy: -2 },
-    stopSign: { width: 20, height: 20 },
-    turnLeft: { width: 15, height: 12, dy: +1 },
-    turnRight: { width: 15, height: 12, dy: +1 },
-    loopArrow: { width: 14, height: 11 },
-    addInput: { width: 4, height: 8 },
-    delInput: { width: 4, height: 8 },
-    list: { width: 12, height: 14 },
+  static get icons() {
+    return {
+      greenFlag: { width: 20, height: 21, dy: -2 },
+      stopSign: { width: 20, height: 20 },
+      turnLeft: { width: 15, height: 12, dy: +1 },
+      turnRight: { width: 15, height: 12, dy: +1 },
+      loopArrow: { width: 14, height: 11 },
+      addInput: { width: 4, height: 8 },
+      delInput: { width: 4, height: 8 },
+      list: { width: 12, height: 14 },
+    }
   }
 }
 
@@ -125,16 +133,18 @@ class InputView {
     if (this.hasLabel) this.label.measure()
   }
 
-  static shapes = {
-    string: SVG.rect,
-    number: SVG.roundedRect,
-    "number-dropdown": SVG.roundedRect,
-    color: SVG.rect,
-    dropdown: SVG.rect,
+  static get shapes() {
+    return {
+      string: SVG.rect,
+      number: SVG.roundedRect,
+      "number-dropdown": SVG.roundedRect,
+      color: SVG.rect,
+      dropdown: SVG.rect,
 
-    boolean: SVG.pointedRect,
-    stack: SVG.stackRect,
-    reporter: SVG.roundedRect,
+      boolean: SVG.pointedRect,
+      stack: SVG.stackRect,
+      reporter: SVG.roundedRect,
+    }
   }
 
   draw(parent) {
@@ -216,7 +226,10 @@ class BlockView {
     this.firstLine = null
     this.innerWidth = null
   }
-  isBlock = true
+
+  get isBlock() {
+    return true
+  }
 
   measure() {
     for (var i = 0; i < this.children.length; i++) {
@@ -226,20 +239,22 @@ class BlockView {
     if (this.comment) this.comment.measure()
   }
 
-  static shapes = {
-    stack: SVG.stackRect,
-    "c-block": SVG.stackRect,
-    "if-block": SVG.stackRect,
-    celse: SVG.stackRect,
-    cend: SVG.stackRect,
+  static get shapes() {
+    return {
+      stack: SVG.stackRect,
+      "c-block": SVG.stackRect,
+      "if-block": SVG.stackRect,
+      celse: SVG.stackRect,
+      cend: SVG.stackRect,
 
-    cap: SVG.capRect,
-    reporter: SVG.roundedRect,
-    boolean: SVG.pointedRect,
-    hat: SVG.hatRect,
-    cat: SVG.hatRect,
-    "define-hat": SVG.procHatRect,
-    ring: SVG.roundedRect,
+      cap: SVG.capRect,
+      reporter: SVG.roundedRect,
+      boolean: SVG.pointedRect,
+      hat: SVG.hatRect,
+      cat: SVG.hatRect,
+      "define-hat": SVG.procHatRect,
+      ring: SVG.roundedRect,
+    }
   }
 
   drawSelf(w, h, lines) {
@@ -303,17 +318,19 @@ class BlockView {
     return 0
   }
 
-  static padding = {
-    hat: [15, 6, 2],
-    cat: [15, 6, 2],
-    "define-hat": [21, 8, 9],
-    reporter: [3, 4, 1],
-    boolean: [3, 4, 2],
-    cap: [6, 6, 2],
-    "c-block": [3, 6, 2],
-    "if-block": [3, 6, 2],
-    ring: [4, 4, 2],
-    null: [4, 6, 2],
+  static get padding() {
+    return {
+      hat: [15, 6, 2],
+      cat: [15, 6, 2],
+      "define-hat": [21, 8, 9],
+      reporter: [3, 4, 1],
+      boolean: [3, 4, 2],
+      cap: [6, 6, 2],
+      "c-block": [3, 6, 2],
+      "if-block": [3, 6, 2],
+      ring: [4, 4, 2],
+      null: [4, 6, 2],
+    }
   }
 
   draw() {
@@ -483,10 +500,18 @@ class CommentView {
 
     this.width = null
   }
-  isComment = true
 
-  static lineLength = 12
-  static height = 20
+  get isComment() {
+    return true
+  }
+
+  static get lineLength() {
+    return 12
+  }
+
+  get height() {
+    return 20
+  }
 
   measure() {
     this.label.measure()
@@ -515,7 +540,10 @@ class GlowView {
     this.height = null
     this.y = 0
   }
-  isGlow = true
+
+  get isGlow() {
+    return true
+  }
 
   measure() {
     this.child.measure()
@@ -562,7 +590,10 @@ class ScriptView {
 
     this.y = 0
   }
-  isScript = true
+
+  get isScript() {
+    return true
+  }
 
   measure() {
     for (var i = 0; i < this.blocks.length; i++) {

--- a/scratch2/blocks.js
+++ b/scratch2/blocks.js
@@ -24,703 +24,705 @@ const {
   darkFilter,
 } = style
 
-/* Label */
+export class LabelView {
+  constructor(label) {
+    Object.assign(this, label)
 
-export var LabelView = function (label) {
-  Object.assign(this, label)
+    this.el = null
+    this.height = 12
+    this.metrics = null
+    this.x = 0
+  }
+  isLabel = true
 
-  this.el = null
-  this.height = 12
-  this.metrics = null
-  this.x = 0
-}
-LabelView.prototype.isLabel = true
+  draw() {
+    return this.el
+  }
 
-LabelView.prototype.draw = function () {
-  return this.el
-}
-
-Object.defineProperty(LabelView.prototype, "width", {
-  get: function () {
+  get width() {
     return this.metrics.width
-  },
-})
-
-LabelView.metricsCache = {}
-LabelView.toMeasure = []
-
-LabelView.prototype.measure = function () {
-  var value = this.value
-  var cls = "sb-" + this.cls
-  this.el = SVG.text(0, 10, value, {
-    class: "sb-label " + cls,
-  })
-
-  var cache = LabelView.metricsCache[cls]
-  if (!cache) {
-    cache = LabelView.metricsCache[cls] = Object.create(null)
   }
 
-  if (Object.hasOwnProperty.call(cache, value)) {
-    this.metrics = cache[value]
-  } else {
-    var font = /comment-label/.test(this.cls)
-      ? "bold 12px Helevetica, Arial, DejaVu Sans, sans-serif"
-      : /literal/.test(this.cls)
-      ? "normal 9px " + defaultFontFamily
-      : "bold 10px " + defaultFontFamily
-    this.metrics = cache[value] = LabelView.measure(value, font)
-    // TODO: word-spacing? (fortunately it seems to have no effect!)
-  }
-}
+  static metricsCache = {}
+  static toMeasure = []
 
-LabelView.measure = function (value, font) {
-  var context = LabelView.measuring
-  context.font = font
-  var textMetrics = context.measureText(value)
-  var width = (textMetrics.width + 0.5) | 0
-  return { width: width }
-}
-
-/* Icon */
-
-var IconView = function (icon) {
-  Object.assign(this, icon)
-
-  const info = IconView.icons[this.name]
-  if (!info) {
-    throw new Error("no info for icon: " + this.name)
-  }
-  Object.assign(this, info)
-}
-IconView.prototype.isIcon = true
-
-IconView.prototype.draw = function () {
-  return SVG.symbol("#" + this.name, {
-    width: this.width,
-    height: this.height,
-  })
-}
-
-IconView.icons = {
-  greenFlag: { width: 20, height: 21, dy: -2 },
-  stopSign: { width: 20, height: 20 },
-  turnLeft: { width: 15, height: 12, dy: +1 },
-  turnRight: { width: 15, height: 12, dy: +1 },
-  loopArrow: { width: 14, height: 11 },
-  addInput: { width: 4, height: 8 },
-  delInput: { width: 4, height: 8 },
-  list: { width: 12, height: 14 },
-}
-
-/* Input */
-
-var InputView = function (input) {
-  Object.assign(this, input)
-  if (input.label) {
-    this.label = newView(input.label)
-  }
-
-  this.x = 0
-}
-
-InputView.prototype.measure = function () {
-  if (this.hasLabel) this.label.measure()
-}
-
-InputView.shapes = {
-  string: SVG.rect,
-  number: SVG.roundedRect,
-  "number-dropdown": SVG.roundedRect,
-  color: SVG.rect,
-  dropdown: SVG.rect,
-
-  boolean: SVG.pointedRect,
-  stack: SVG.stackRect,
-  reporter: SVG.roundedRect,
-}
-
-InputView.prototype.draw = function (parent) {
-  if (this.hasLabel) {
-    var label = this.label.draw()
-    var w = Math.max(
-      14,
-      this.label.width +
-        (this.shape === "string" || this.shape === "number-dropdown" ? 6 : 9)
-    )
-  } else {
-    var w = this.isInset ? 30 : this.isColor ? 13 : null
-  }
-  if (this.hasArrow) w += 10
-  this.width = w
-
-  var h = (this.height = this.isRound || this.isColor ? 13 : 14)
-
-  var el = InputView.shapes[this.shape](w, h)
-  if (this.isColor) {
-    SVG.setProps(el, {
-      fill: this.value,
+  measure() {
+    var value = this.value
+    var cls = "sb-" + this.cls
+    this.el = SVG.text(0, 10, value, {
+      class: "sb-label " + cls,
     })
-  } else if (this.isDarker) {
-    el = darkRect(w, h, parent.info.category, el)
-    if (parent.info.color) {
-      SVG.setProps(el, {
-        fill: parent.info.color,
-      })
+
+    var cache = LabelView.metricsCache[cls]
+    if (!cache) {
+      cache = LabelView.metricsCache[cls] = Object.create(null)
+    }
+
+    if (Object.hasOwnProperty.call(cache, value)) {
+      this.metrics = cache[value]
+    } else {
+      var font = /comment-label/.test(this.cls)
+        ? "bold 12px Helevetica, Arial, DejaVu Sans, sans-serif"
+        : /literal/.test(this.cls)
+        ? "normal 9px " + defaultFontFamily
+        : "bold 10px " + defaultFontFamily
+      this.metrics = cache[value] = LabelView.measure(value, font)
+      // TODO: word-spacing? (fortunately it seems to have no effect!)
     }
   }
 
-  var result = SVG.group([
-    SVG.setProps(el, {
-      class: ["sb-input", "sb-input-" + this.shape].join(" "),
-    }),
-  ])
-  if (this.hasLabel) {
-    var x = this.isRound ? 5 : 4
-    result.appendChild(SVG.move(x, 0, label))
+  static measure(value, font) {
+    var context = LabelView.measuring
+    context.font = font
+    var textMetrics = context.measureText(value)
+    var width = (textMetrics.width + 0.5) | 0
+    return { width: width }
   }
-  if (this.hasArrow) {
-    var y = this.shape === "dropdown" ? 5 : 4
-    result.appendChild(
-      SVG.move(
-        w - 10,
-        y,
-        SVG.polygon({
-          points: [7, 0, 3.5, 4, 0, 0],
-          fill: "#000",
-          opacity: "0.6",
-        })
+}
+
+class IconView {
+  constructor(icon) {
+    Object.assign(this, icon)
+
+    const info = IconView.icons[this.name]
+    if (!info) {
+      throw new Error("no info for icon: " + this.name)
+    }
+    Object.assign(this, info)
+  }
+  isIcon = true
+
+  draw() {
+    return SVG.symbol("#" + this.name, {
+      width: this.width,
+      height: this.height,
+    })
+  }
+
+  static icons = {
+    greenFlag: { width: 20, height: 21, dy: -2 },
+    stopSign: { width: 20, height: 20 },
+    turnLeft: { width: 15, height: 12, dy: +1 },
+    turnRight: { width: 15, height: 12, dy: +1 },
+    loopArrow: { width: 14, height: 11 },
+    addInput: { width: 4, height: 8 },
+    delInput: { width: 4, height: 8 },
+    list: { width: 12, height: 14 },
+  }
+}
+
+class InputView {
+  constructor(input) {
+    Object.assign(this, input)
+    if (input.label) {
+      this.label = newView(input.label)
+    }
+
+    this.x = 0
+  }
+
+  measure() {
+    if (this.hasLabel) this.label.measure()
+  }
+
+  static shapes = {
+    string: SVG.rect,
+    number: SVG.roundedRect,
+    "number-dropdown": SVG.roundedRect,
+    color: SVG.rect,
+    dropdown: SVG.rect,
+
+    boolean: SVG.pointedRect,
+    stack: SVG.stackRect,
+    reporter: SVG.roundedRect,
+  }
+
+  draw(parent) {
+    if (this.hasLabel) {
+      var label = this.label.draw()
+      var w = Math.max(
+        14,
+        this.label.width +
+          (this.shape === "string" || this.shape === "number-dropdown" ? 6 : 9)
       )
-    )
+    } else {
+      var w = this.isInset ? 30 : this.isColor ? 13 : null
+    }
+    if (this.hasArrow) w += 10
+    this.width = w
+
+    var h = (this.height = this.isRound || this.isColor ? 13 : 14)
+
+    var el = InputView.shapes[this.shape](w, h)
+    if (this.isColor) {
+      SVG.setProps(el, {
+        fill: this.value,
+      })
+    } else if (this.isDarker) {
+      el = darkRect(w, h, parent.info.category, el)
+      if (parent.info.color) {
+        SVG.setProps(el, {
+          fill: parent.info.color,
+        })
+      }
+    }
+
+    var result = SVG.group([
+      SVG.setProps(el, {
+        class: ["sb-input", "sb-input-" + this.shape].join(" "),
+      }),
+    ])
+    if (this.hasLabel) {
+      var x = this.isRound ? 5 : 4
+      result.appendChild(SVG.move(x, 0, label))
+    }
+    if (this.hasArrow) {
+      var y = this.shape === "dropdown" ? 5 : 4
+      result.appendChild(
+        SVG.move(
+          w - 10,
+          y,
+          SVG.polygon({
+            points: [7, 0, 3.5, 4, 0, 0],
+            fill: "#000",
+            opacity: "0.6",
+          })
+        )
+      )
+    }
+    return result
   }
-  return result
 }
 
-/* Block */
+class BlockView {
+  constructor(block) {
+    Object.assign(this, block)
+    this.children = block.children.map(newView)
+    this.comment = this.comment ? newView(this.comment) : null
 
-var BlockView = function (block) {
-  Object.assign(this, block)
-  this.children = block.children.map(newView)
-  this.comment = this.comment ? newView(this.comment) : null
+    if (aliasExtensions.hasOwnProperty(this.info.category)) {
+      // handle aliases first
+      this.info.category = aliasExtensions[this.info.category]
+    }
+    if (movedExtensions.hasOwnProperty(this.info.category)) {
+      this.info.category = movedExtensions[this.info.category]
+    } else if (extensions.hasOwnProperty(this.info.category)) {
+      this.info.category = "extension"
+    }
 
-  if (aliasExtensions.hasOwnProperty(this.info.category)) {
-    // handle aliases first
-    this.info.category = aliasExtensions[this.info.category]
+    this.x = 0
+    this.width = null
+    this.height = null
+    this.firstLine = null
+    this.innerWidth = null
   }
-  if (movedExtensions.hasOwnProperty(this.info.category)) {
-    this.info.category = movedExtensions[this.info.category]
-  } else if (extensions.hasOwnProperty(this.info.category)) {
-    this.info.category = "extension"
+  isBlock = true
+
+  measure() {
+    for (var i = 0; i < this.children.length; i++) {
+      var child = this.children[i]
+      if (child.measure) child.measure()
+    }
+    if (this.comment) this.comment.measure()
   }
 
-  this.x = 0
-  this.width = null
-  this.height = null
-  this.firstLine = null
-  this.innerWidth = null
-}
-BlockView.prototype.isBlock = true
+  static shapes = {
+    stack: SVG.stackRect,
+    "c-block": SVG.stackRect,
+    "if-block": SVG.stackRect,
+    celse: SVG.stackRect,
+    cend: SVG.stackRect,
 
-BlockView.prototype.measure = function () {
-  for (var i = 0; i < this.children.length; i++) {
-    var child = this.children[i]
-    if (child.measure) child.measure()
+    cap: SVG.capRect,
+    reporter: SVG.roundedRect,
+    boolean: SVG.pointedRect,
+    hat: SVG.hatRect,
+    cat: SVG.hatRect,
+    "define-hat": SVG.procHatRect,
+    ring: SVG.roundedRect,
   }
-  if (this.comment) this.comment.measure()
-}
 
-BlockView.shapes = {
-  stack: SVG.stackRect,
-  "c-block": SVG.stackRect,
-  "if-block": SVG.stackRect,
-  celse: SVG.stackRect,
-  cend: SVG.stackRect,
+  drawSelf(w, h, lines) {
+    // mouths
+    if (lines.length > 1) {
+      return SVG.mouthRect(w, h, this.isFinal, lines, {
+        class: ["sb-" + this.info.category, "sb-bevel"].join(" "),
+      })
+    }
 
-  cap: SVG.capRect,
-  reporter: SVG.roundedRect,
-  boolean: SVG.pointedRect,
-  hat: SVG.hatRect,
-  cat: SVG.hatRect,
-  "define-hat": SVG.procHatRect,
-  ring: SVG.roundedRect,
-}
+    // outlines
+    if (this.info.shape === "outline") {
+      return SVG.setProps(SVG.stackRect(w, h), {
+        class: "sb-outline",
+      })
+    }
 
-BlockView.prototype.drawSelf = function (w, h, lines) {
-  // mouths
-  if (lines.length > 1) {
-    return SVG.mouthRect(w, h, this.isFinal, lines, {
+    // rings
+    if (this.isRing) {
+      var child = this.children[0]
+      // We use isStack for InputView; isBlock for BlockView; isScript for ScriptView.
+      if (child && (child.isStack || child.isBlock || child.isScript)) {
+        var shape = child.isScript
+          ? "stack"
+          : child.isStack
+          ? child.shape
+          : child.info.shape
+        return SVG.ringRect(w, h, child.y, child.width, child.height, shape, {
+          class: ["sb-" + this.info.category, "sb-bevel"].join(" "),
+        })
+      }
+    }
+
+    var func = BlockView.shapes[this.info.shape]
+    if (!func) {
+      throw new Error("no shape func: " + this.info.shape)
+    }
+    return func(w, h, {
       class: ["sb-" + this.info.category, "sb-bevel"].join(" "),
     })
   }
 
-  // outlines
-  if (this.info.shape === "outline") {
-    return SVG.setProps(SVG.stackRect(w, h), {
-      class: "sb-outline",
-    })
-  }
-
-  // rings
-  if (this.isRing) {
-    var child = this.children[0]
-    // We use isStack for InputView; isBlock for BlockView; isScript for ScriptView.
-    if (child && (child.isStack || child.isBlock || child.isScript)) {
-      var shape = child.isScript
-        ? "stack"
-        : child.isStack
-        ? child.shape
-        : child.info.shape
-      return SVG.ringRect(w, h, child.y, child.width, child.height, shape, {
-        class: ["sb-" + this.info.category, "sb-bevel"].join(" "),
-      })
+  minDistance(child) {
+    if (this.isBoolean) {
+      return child.isReporter
+        ? (4 + child.height / 4) | 0
+        : child.isLabel
+        ? (5 + child.height / 2) | 0
+        : child.isBoolean || child.shape === "boolean"
+        ? 5
+        : (2 + child.height / 2) | 0
     }
-  }
-
-  var func = BlockView.shapes[this.info.shape]
-  if (!func) {
-    throw new Error("no shape func: " + this.info.shape)
-  }
-  return func(w, h, {
-    class: ["sb-" + this.info.category, "sb-bevel"].join(" "),
-  })
-}
-
-BlockView.prototype.minDistance = function (child) {
-  if (this.isBoolean) {
-    return child.isReporter
-      ? (4 + child.height / 4) | 0
-      : child.isLabel
-      ? (5 + child.height / 2) | 0
-      : child.isBoolean || child.shape === "boolean"
-      ? 5
-      : (2 + child.height / 2) | 0
-  }
-  if (this.isReporter) {
-    return (child.isInput && child.isRound) ||
-      ((child.isReporter || child.isBoolean) && !child.hasScript)
-      ? 0
-      : child.isLabel
-      ? (2 + child.height / 2) | 0
-      : (-2 + child.height / 2) | 0
-  }
-  return 0
-}
-
-BlockView.padding = {
-  hat: [15, 6, 2],
-  cat: [15, 6, 2],
-  "define-hat": [21, 8, 9],
-  reporter: [3, 4, 1],
-  boolean: [3, 4, 2],
-  cap: [6, 6, 2],
-  "c-block": [3, 6, 2],
-  "if-block": [3, 6, 2],
-  ring: [4, 4, 2],
-  null: [4, 6, 2],
-}
-
-BlockView.prototype.draw = function () {
-  var isDefine = this.info.shape === "define-hat"
-  var children = this.children
-
-  var padding = BlockView.padding[this.info.shape] || BlockView.padding[null]
-  var pt = padding[0],
-    px = padding[1],
-    pb = padding[2]
-
-  var y = 0
-  var Line = function (y) {
-    this.y = y
-    this.width = 0
-    this.height = y ? 13 : 16
-    this.children = []
-  }
-
-  var innerWidth = 0
-  var scriptWidth = 0
-  var line = new Line(y)
-  function pushLine(isLast) {
-    if (lines.length === 0) {
-      line.height += pt + pb
-    } else {
-      line.height += isLast ? 0 : +2
-      line.y -= 1
+    if (this.isReporter) {
+      return (child.isInput && child.isRound) ||
+        ((child.isReporter || child.isBoolean) && !child.hasScript)
+        ? 0
+        : child.isLabel
+        ? (2 + child.height / 2) | 0
+        : (-2 + child.height / 2) | 0
     }
-    y += line.height
-    lines.push(line)
+    return 0
   }
 
-  if (this.info.isRTL) {
-    var start = 0
-    var flip = function () {
-      children = children
-        .slice(0, start)
-        .concat(children.slice(start, i).reverse())
-        .concat(children.slice(i))
-    }.bind(this)
-    for (var i = 0; i < children.length; i++) {
-      if (children[i].isScript) {
+  static padding = {
+    hat: [15, 6, 2],
+    cat: [15, 6, 2],
+    "define-hat": [21, 8, 9],
+    reporter: [3, 4, 1],
+    boolean: [3, 4, 2],
+    cap: [6, 6, 2],
+    "c-block": [3, 6, 2],
+    "if-block": [3, 6, 2],
+    ring: [4, 4, 2],
+    null: [4, 6, 2],
+  }
+
+  draw() {
+    var isDefine = this.info.shape === "define-hat"
+    var children = this.children
+
+    var padding = BlockView.padding[this.info.shape] || BlockView.padding[null]
+    var pt = padding[0],
+      px = padding[1],
+      pb = padding[2]
+
+    var y = 0
+    var Line = function (y) {
+      this.y = y
+      this.width = 0
+      this.height = y ? 13 : 16
+      this.children = []
+    }
+
+    var innerWidth = 0
+    var scriptWidth = 0
+    var line = new Line(y)
+    function pushLine(isLast) {
+      if (lines.length === 0) {
+        line.height += pt + pb
+      } else {
+        line.height += isLast ? 0 : +2
+        line.y -= 1
+      }
+      y += line.height
+      lines.push(line)
+    }
+
+    if (this.info.isRTL) {
+      var start = 0
+      var flip = function () {
+        children = children
+          .slice(0, start)
+          .concat(children.slice(start, i).reverse())
+          .concat(children.slice(i))
+      }.bind(this)
+      for (var i = 0; i < children.length; i++) {
+        if (children[i].isScript) {
+          flip()
+          start = i + 1
+        }
+      }
+      if (start < i) {
         flip()
-        start = i + 1
       }
     }
-    if (start < i) {
-      flip()
-    }
-  }
 
-  var lines = []
-  for (var i = 0; i < children.length; i++) {
-    var child = children[i]
-    child.el = child.draw(this)
+    var lines = []
+    for (var i = 0; i < children.length; i++) {
+      var child = children[i]
+      child.el = child.draw(this)
 
-    if (child.isScript && this.isCommand) {
-      this.hasScript = true
-      pushLine()
-      child.y = y
-      lines.push(child)
-      scriptWidth = Math.max(scriptWidth, Math.max(1, child.width))
-      child.height = Math.max(12, child.height) + 3
-      y += child.height
-      line = new Line(y)
-    } else if (child.isArrow) {
-      line.children.push(child)
-    } else {
-      var cmw = i > 0 ? 30 : 0 // 27
-      var md = this.isCommand ? 0 : this.minDistance(child)
-      var mw = this.isCommand ? (child.isBlock || child.isInput ? cmw : 0) : md
-      if (mw && !lines.length && line.width < mw - px) {
-        line.width = mw - px
+      if (child.isScript && this.isCommand) {
+        this.hasScript = true
+        pushLine()
+        child.y = y
+        lines.push(child)
+        scriptWidth = Math.max(scriptWidth, Math.max(1, child.width))
+        child.height = Math.max(12, child.height) + 3
+        y += child.height
+        line = new Line(y)
+      } else if (child.isArrow) {
+        line.children.push(child)
+      } else {
+        var cmw = i > 0 ? 30 : 0 // 27
+        var md = this.isCommand ? 0 : this.minDistance(child)
+        var mw = this.isCommand
+          ? child.isBlock || child.isInput
+            ? cmw
+            : 0
+          : md
+        if (mw && !lines.length && line.width < mw - px) {
+          line.width = mw - px
+        }
+        child.x = line.width
+        line.width += child.width
+        innerWidth = Math.max(innerWidth, line.width + Math.max(0, md - px))
+        line.width += 4
+        if (!child.isLabel) {
+          line.height = Math.max(line.height, child.height)
+        }
+        line.children.push(child)
       }
-      child.x = line.width
-      line.width += child.width
-      innerWidth = Math.max(innerWidth, line.width + Math.max(0, md - px))
-      line.width += 4
-      if (!child.isLabel) {
-        line.height = Math.max(line.height, child.height)
-      }
-      line.children.push(child)
     }
-  }
-  pushLine(true)
+    pushLine(true)
 
-  innerWidth = Math.max(
-    innerWidth + px * 2,
-    this.isHat || this.hasScript
-      ? 83
-      : this.isCommand || this.isOutline || this.isRing
-      ? 39
-      : 20
-  )
-  this.height = y
-  this.width = scriptWidth ? Math.max(innerWidth, 15 + scriptWidth) : innerWidth
-  if (isDefine) {
-    var p = Math.min(26, (3.5 + 0.13 * innerWidth) | 0) - 18
-    this.height += p
-    pt += 2 * p
-  }
-  this.firstLine = lines[0]
-  this.innerWidth = innerWidth
-
-  var objects = []
-
-  for (var i = 0; i < lines.length; i++) {
-    var line = lines[i]
-    if (line.isScript) {
-      objects.push(SVG.move(15, line.y, line.el))
-      continue
+    innerWidth = Math.max(
+      innerWidth + px * 2,
+      this.isHat || this.hasScript
+        ? 83
+        : this.isCommand || this.isOutline || this.isRing
+        ? 39
+        : 20
+    )
+    this.height = y
+    this.width = scriptWidth
+      ? Math.max(innerWidth, 15 + scriptWidth)
+      : innerWidth
+    if (isDefine) {
+      var p = Math.min(26, (3.5 + 0.13 * innerWidth) | 0) - 18
+      this.height += p
+      pt += 2 * p
     }
+    this.firstLine = lines[0]
+    this.innerWidth = innerWidth
 
-    var h = line.height
+    var objects = []
 
-    for (var j = 0; j < line.children.length; j++) {
-      var child = line.children[j]
-      if (child.isArrow) {
-        objects.push(SVG.move(innerWidth - 15, this.height - 3, child.el))
+    for (var i = 0; i < lines.length; i++) {
+      var line = lines[i]
+      if (line.isScript) {
+        objects.push(SVG.move(15, line.y, line.el))
         continue
       }
 
-      var y = pt + (h - child.height - pt - pb) / 2 - 1
-      if (isDefine && child.isLabel) {
-        y += 3
-      } else if (child.isIcon) {
-        y += child.dy | 0
-      }
-      if (this.isRing) {
-        child.y = (line.y + y) | 0
-        if (child.isInset) {
+      var h = line.height
+
+      for (var j = 0; j < line.children.length; j++) {
+        var child = line.children[j]
+        if (child.isArrow) {
+          objects.push(SVG.move(innerWidth - 15, this.height - 3, child.el))
           continue
         }
-      }
-      objects.push(SVG.move(px + child.x, (line.y + y) | 0, child.el))
 
-      if (child.diff === "+") {
-        var ellipse = SVG.insEllipse(child.width, child.height)
-        objects.push(SVG.move(px + child.x, (line.y + y) | 0, ellipse))
+        var y = pt + (h - child.height - pt - pb) / 2 - 1
+        if (isDefine && child.isLabel) {
+          y += 3
+        } else if (child.isIcon) {
+          y += child.dy | 0
+        }
+        if (this.isRing) {
+          child.y = (line.y + y) | 0
+          if (child.isInset) {
+            continue
+          }
+        }
+        objects.push(SVG.move(px + child.x, (line.y + y) | 0, child.el))
+
+        if (child.diff === "+") {
+          var ellipse = SVG.insEllipse(child.width, child.height)
+          objects.push(SVG.move(px + child.x, (line.y + y) | 0, ellipse))
+        }
       }
+    }
+
+    var el = this.drawSelf(innerWidth, this.height, lines)
+    objects.splice(0, 0, el)
+    if (this.info.color) {
+      SVG.setProps(el, {
+        fill: this.info.color,
+      })
+    }
+
+    return SVG.group(objects)
+  }
+}
+
+class CommentView {
+  constructor(comment) {
+    Object.assign(this, comment)
+    this.label = newView(comment.label)
+
+    this.width = null
+  }
+  isComment = true
+
+  static lineLength = 12
+  static height = 20
+
+  measure() {
+    this.label.measure()
+  }
+
+  draw() {
+    var labelEl = this.label.draw()
+
+    this.width = this.label.width + 16
+    return SVG.group([
+      SVG.commentLine(this.hasBlock ? CommentView.lineLength : 0, 6),
+      SVG.commentRect(this.width, this.height, {
+        class: "sb-comment",
+      }),
+      SVG.move(8, 4, labelEl),
+    ])
+  }
+}
+
+class GlowView {
+  constructor(glow) {
+    Object.assign(this, glow)
+    this.child = newView(glow.child)
+
+    this.width = null
+    this.height = null
+    this.y = 0
+  }
+  isGlow = true
+
+  measure() {
+    this.child.measure()
+  }
+
+  drawSelf() {
+    var c = this.child
+    var el
+    var w = this.width
+    var h = this.height - 1
+    if (c.isScript) {
+      if (!c.isEmpty && c.blocks[0].isHat) {
+        el = SVG.hatRect(w, h)
+      } else if (c.isFinal) {
+        el = SVG.capRect(w, h)
+      } else {
+        el = SVG.stackRect(w, h)
+      }
+    } else {
+      var el = c.drawSelf(w, h, [])
+    }
+    return SVG.setProps(el, {
+      class: "sb-diff sb-diff-ins",
+    })
+  }
+  // TODO how can we always raise Glows above their parents?
+
+  draw() {
+    var c = this.child
+    var el = c.isScript ? c.draw(true) : c.draw()
+
+    this.width = c.width
+    this.height = (c.isBlock && c.firstLine.height) || c.height
+
+    // encircle
+    return SVG.group([el, this.drawSelf()])
+  }
+}
+
+class ScriptView {
+  constructor(script) {
+    Object.assign(this, script)
+    this.blocks = script.blocks.map(newView)
+
+    this.y = 0
+  }
+  isScript = true
+
+  measure() {
+    for (var i = 0; i < this.blocks.length; i++) {
+      this.blocks[i].measure()
     }
   }
 
-  var el = this.drawSelf(innerWidth, this.height, lines)
-  objects.splice(0, 0, el)
-  if (this.info.color) {
-    SVG.setProps(el, {
-      fill: this.info.color,
+  draw(inside) {
+    var children = []
+    var y = 0
+    this.width = 0
+    for (var i = 0; i < this.blocks.length; i++) {
+      var block = this.blocks[i]
+      var x = inside ? 0 : 2
+      var child = block.draw()
+      children.push(SVG.move(x, y, child))
+      this.width = Math.max(this.width, block.width)
+
+      var diff = block.diff
+      if (diff === "-") {
+        var dw = block.width
+        var dh = block.firstLine.height || block.height
+        children.push(SVG.move(x, y + dh / 2 + 1, SVG.strikethroughLine(dw)))
+        this.width = Math.max(this.width, block.width)
+      }
+
+      y += block.height
+
+      var comment = block.comment
+      if (comment) {
+        var line = block.firstLine
+        var cx = block.innerWidth + 2 + CommentView.lineLength
+        var cy = y - block.height + line.height / 2
+        var el = comment.draw()
+        children.push(SVG.move(cx, cy - comment.height / 2, el))
+        this.width = Math.max(this.width, cx + comment.width)
+      }
+    }
+    this.height = y
+    if (!inside && !this.isFinal) {
+      this.height += 3
+    }
+    if (!inside && block.isGlow) {
+      this.height += 2 // TODO unbreak this
+    }
+    return SVG.group(children)
+  }
+}
+
+class DocumentView {
+  constructor(doc, options) {
+    Object.assign(this, doc)
+    this.scripts = doc.scripts.map(newView)
+
+    this.width = null
+    this.height = null
+    this.el = null
+    this.defs = null
+    this.scale = options.scale
+  }
+
+  measure() {
+    this.scripts.forEach(function (script) {
+      script.measure()
     })
   }
 
-  return SVG.group(objects)
-}
-
-/* Comment */
-
-var CommentView = function (comment) {
-  Object.assign(this, comment)
-  this.label = newView(comment.label)
-
-  this.width = null
-}
-CommentView.prototype.isComment = true
-
-CommentView.lineLength = 12
-CommentView.prototype.height = 20
-
-CommentView.prototype.measure = function () {
-  this.label.measure()
-}
-
-CommentView.prototype.draw = function () {
-  var labelEl = this.label.draw()
-
-  this.width = this.label.width + 16
-  return SVG.group([
-    SVG.commentLine(this.hasBlock ? CommentView.lineLength : 0, 6),
-    SVG.commentRect(this.width, this.height, {
-      class: "sb-comment",
-    }),
-    SVG.move(8, 4, labelEl),
-  ])
-}
-
-/* Glow */
-
-var GlowView = function (glow) {
-  Object.assign(this, glow)
-  this.child = newView(glow.child)
-
-  this.width = null
-  this.height = null
-  this.y = 0
-}
-GlowView.prototype.isGlow = true
-
-GlowView.prototype.measure = function () {
-  this.child.measure()
-}
-
-GlowView.prototype.drawSelf = function () {
-  var c = this.child
-  var el
-  var w = this.width
-  var h = this.height - 1
-  if (c.isScript) {
-    if (!c.isEmpty && c.blocks[0].isHat) {
-      el = SVG.hatRect(w, h)
-    } else if (c.isFinal) {
-      el = SVG.capRect(w, h)
-    } else {
-      el = SVG.stackRect(w, h)
-    }
-  } else {
-    var el = c.drawSelf(w, h, [])
-  }
-  return SVG.setProps(el, {
-    class: "sb-diff sb-diff-ins",
-  })
-}
-// TODO how can we always raise Glows above their parents?
-
-GlowView.prototype.draw = function () {
-  var c = this.child
-  var el = c.isScript ? c.draw(true) : c.draw()
-
-  this.width = c.width
-  this.height = (c.isBlock && c.firstLine.height) || c.height
-
-  // encircle
-  return SVG.group([el, this.drawSelf()])
-}
-
-/* Script */
-
-var ScriptView = function (script) {
-  Object.assign(this, script)
-  this.blocks = script.blocks.map(newView)
-
-  this.y = 0
-}
-ScriptView.prototype.isScript = true
-
-ScriptView.prototype.measure = function () {
-  for (var i = 0; i < this.blocks.length; i++) {
-    this.blocks[i].measure()
-  }
-}
-
-ScriptView.prototype.draw = function (inside) {
-  var children = []
-  var y = 0
-  this.width = 0
-  for (var i = 0; i < this.blocks.length; i++) {
-    var block = this.blocks[i]
-    var x = inside ? 0 : 2
-    var child = block.draw()
-    children.push(SVG.move(x, y, child))
-    this.width = Math.max(this.width, block.width)
-
-    var diff = block.diff
-    if (diff === "-") {
-      var dw = block.width
-      var dh = block.firstLine.height || block.height
-      children.push(SVG.move(x, y + dh / 2 + 1, SVG.strikethroughLine(dw)))
-      this.width = Math.max(this.width, block.width)
+  render(cb) {
+    if (typeof ocbptions === "function") {
+      throw new Error("render() no longer takes a callback")
     }
 
-    y += block.height
+    // measure strings
+    this.measure()
 
-    var comment = block.comment
-    if (comment) {
-      var line = block.firstLine
-      var cx = block.innerWidth + 2 + CommentView.lineLength
-      var cy = y - block.height + line.height / 2
-      var el = comment.draw()
-      children.push(SVG.move(cx, cy - comment.height / 2, el))
-      this.width = Math.max(this.width, cx + comment.width)
+    // TODO: separate layout + render steps.
+    // render each script
+    var width = 0
+    var height = 0
+    var elements = []
+    for (var i = 0; i < this.scripts.length; i++) {
+      var script = this.scripts[i]
+      if (height) height += 10
+      script.y = height
+      elements.push(SVG.move(0, height, script.draw()))
+      height += script.height
+      width = Math.max(width, script.width + 4)
+    }
+    this.width = width
+    this.height = height
+
+    // return SVG
+    var svg = SVG.newSVG(width, height, this.scale)
+    svg.appendChild(
+      (this.defs = SVG.withChildren(
+        SVG.el("defs"),
+        [
+          bevelFilter("bevelFilter", false),
+          bevelFilter("inputBevelFilter", true),
+          darkFilter("inputDarkFilter"),
+        ].concat(makeIcons())
+      ))
+    )
+
+    svg.appendChild(SVG.group(elements))
+    this.el = svg
+    return svg
+  }
+
+  /* Export SVG image as XML string */
+  exportSVGString() {
+    if (this.el == null) {
+      throw new Error("call draw() first")
+    }
+
+    var style = makeStyle()
+    this.defs.appendChild(style)
+    var xml = new SVG.XMLSerializer().serializeToString(this.el)
+    this.defs.removeChild(style)
+    return xml
+  }
+
+  /* Export SVG image as data URI */
+  exportSVG() {
+    var xml = this.exportSVGString()
+    return "data:image/svg+xml;utf8," + xml.replace(/[#]/g, encodeURIComponent)
+  }
+
+  toCanvas(cb, exportScale) {
+    exportScale = exportScale || 1.0
+
+    var canvas = SVG.makeCanvas()
+    canvas.width = Math.max(1, this.width * exportScale * this.scale)
+    canvas.height = Math.max(1, this.height * exportScale * this.scale)
+    var context = canvas.getContext("2d")
+
+    var image = new Image()
+    image.src = this.exportSVG()
+    image.onload = function () {
+      context.save()
+      context.scale(exportScale, exportScale)
+      context.drawImage(image, 0, 0)
+      context.restore()
+
+      cb(canvas)
     }
   }
-  this.height = y
-  if (!inside && !this.isFinal) {
-    this.height += 3
-  }
-  if (!inside && block.isGlow) {
-    this.height += 2 // TODO unbreak this
-  }
-  return SVG.group(children)
-}
 
-/* Document */
-
-var DocumentView = function (doc, options) {
-  Object.assign(this, doc)
-  this.scripts = doc.scripts.map(newView)
-
-  this.width = null
-  this.height = null
-  this.el = null
-  this.defs = null
-  this.scale = options.scale
-}
-
-DocumentView.prototype.measure = function () {
-  this.scripts.forEach(function (script) {
-    script.measure()
-  })
-}
-
-DocumentView.prototype.render = function (cb) {
-  if (typeof ocbptions === "function") {
-    throw new Error("render() no longer takes a callback")
-  }
-
-  // measure strings
-  this.measure()
-
-  // TODO: separate layout + render steps.
-  // render each script
-  var width = 0
-  var height = 0
-  var elements = []
-  for (var i = 0; i < this.scripts.length; i++) {
-    var script = this.scripts[i]
-    if (height) height += 10
-    script.y = height
-    elements.push(SVG.move(0, height, script.draw()))
-    height += script.height
-    width = Math.max(width, script.width + 4)
-  }
-  this.width = width
-  this.height = height
-
-  // return SVG
-  var svg = SVG.newSVG(width, height, this.scale)
-  svg.appendChild(
-    (this.defs = SVG.withChildren(
-      SVG.el("defs"),
-      [
-        bevelFilter("bevelFilter", false),
-        bevelFilter("inputBevelFilter", true),
-        darkFilter("inputDarkFilter"),
-      ].concat(makeIcons())
-    ))
-  )
-
-  svg.appendChild(SVG.group(elements))
-  this.el = svg
-  return svg
-}
-
-/* Export SVG image as XML string */
-DocumentView.prototype.exportSVGString = function () {
-  if (this.el == null) {
-    throw new Error("call draw() first")
-  }
-
-  var style = makeStyle()
-  this.defs.appendChild(style)
-  var xml = new SVG.XMLSerializer().serializeToString(this.el)
-  this.defs.removeChild(style)
-  return xml
-}
-
-/* Export SVG image as data URI */
-DocumentView.prototype.exportSVG = function () {
-  var xml = this.exportSVGString()
-  return "data:image/svg+xml;utf8," + xml.replace(/[#]/g, encodeURIComponent)
-}
-
-DocumentView.prototype.toCanvas = function (cb, exportScale) {
-  exportScale = exportScale || 1.0
-
-  var canvas = SVG.makeCanvas()
-  canvas.width = Math.max(1, this.width * exportScale * this.scale)
-  canvas.height = Math.max(1, this.height * exportScale * this.scale)
-  var context = canvas.getContext("2d")
-
-  var image = new Image()
-  image.src = this.exportSVG()
-  image.onload = function () {
-    context.save()
-    context.scale(exportScale, exportScale)
-    context.drawImage(image, 0, 0)
-    context.restore()
-
-    cb(canvas)
+  exportPNG(cb, scale) {
+    this.toCanvas(function (canvas) {
+      if (URL && URL.createObjectURL && Blob && canvas.toBlob) {
+        var blob = canvas.toBlob(function (blob) {
+          cb(URL.createObjectURL(blob))
+        }, "image/png")
+      } else {
+        cb(canvas.toDataURL("image/png"))
+      }
+    }, scale)
   }
 }
-
-DocumentView.prototype.exportPNG = function (cb, scale) {
-  this.toCanvas(function (canvas) {
-    if (URL && URL.createObjectURL && Blob && canvas.toBlob) {
-      var blob = canvas.toBlob(function (blob) {
-        cb(URL.createObjectURL(blob))
-      }, "image/png")
-    } else {
-      cb(canvas.toDataURL("image/png"))
-    }
-  }, scale)
-}
-
-/* view */
 
 const viewFor = node => {
   switch (node.constructor) {

--- a/scratch2/draw.js
+++ b/scratch2/draw.js
@@ -403,7 +403,7 @@ export default SVG = {
       SVG.group([
         SVG.procHatBase(w, q, archRoundness, props),
         SVG.procHatCap(w, q, archRoundness),
-      ])
+      ]),
     )
   },
 
@@ -471,7 +471,7 @@ export default SVG = {
     return SVG.move(
       -width,
       9,
-      SVG.rect(width, 2, { ...props, class: "sb-comment-line" })
+      SVG.rect(width, 2, { ...props, class: "sb-comment-line" }),
     )
   },
 

--- a/scratch2/draw.js
+++ b/scratch2/draw.js
@@ -1,8 +1,5 @@
 /* for constucting SVGs */
 
-function extend(src, dest) {
-  return Object.assign({}, src, dest)
-}
 function assert(bool, message) {
   if (!bool) throw "Assertion failed! " + (message || "")
 }
@@ -70,33 +67,15 @@ export default SVG = {
   },
 
   polygon(props) {
-    return SVG.el(
-      "polygon",
-      extend(props, {
-        points: props.points.join(" "),
-      })
-    )
+    return SVG.el("polygon", { ...props, points: props.points.join(" ") })
   },
 
   path(props) {
-    return SVG.el(
-      "path",
-      extend(props, {
-        path: null,
-        d: props.path.join(" "),
-      })
-    )
+    return SVG.el("path", { ...props, path: null, d: props.path.join(" ") })
   },
 
   text(x, y, content, props) {
-    var text = SVG.el(
-      "text",
-      extend(props, {
-        x: x,
-        y: y,
-        textContent: content,
-      })
-    )
+    var text = SVG.el("text", { ...props, x: x, y: y, textContent: content })
     return text
   },
 
@@ -141,27 +120,17 @@ export default SVG = {
   /* shapes */
 
   rect(w, h, props) {
-    return SVG.el(
-      "rect",
-      extend(props, {
-        x: 0,
-        y: 0,
-        width: w,
-        height: h,
-      })
-    )
+    return SVG.el("rect", { ...props, x: 0, y: 0, width: w, height: h })
   },
 
   ellipse(w, h, props) {
-    return SVG.el(
-      "ellipse",
-      extend(props, {
-        cx: w / 2,
-        cy: h / 2,
-        rx: w / 2,
-        ry: h / 2,
-      })
-    )
+    return SVG.el("ellipse", {
+      ...props,
+      cx: w / 2,
+      cy: h / 2,
+      rx: w / 2,
+      ry: h / 2,
+    })
   },
 
   arc(p1x, p1y, p2x, p2y, rx, ry) {
@@ -187,11 +156,7 @@ export default SVG = {
   },
 
   roundedRect(w, h, props) {
-    return SVG.path(
-      extend(props, {
-        path: SVG.roundedPath(w, h),
-      })
-    )
+    return SVG.path({ ...props, path: SVG.roundedPath(w, h) })
   },
 
   pointedPath(w, h) {
@@ -225,11 +190,7 @@ export default SVG = {
   },
 
   pointedRect(w, h, props) {
-    return SVG.path(
-      extend(props, {
-        path: SVG.pointedPath(w, h),
-      })
-    )
+    return SVG.path({ ...props, path: SVG.pointedPath(w, h) })
   },
 
   getTop(w) {
@@ -337,11 +298,10 @@ export default SVG = {
   },
 
   stackRect(w, h, props) {
-    return SVG.path(
-      extend(props, {
-        path: [SVG.getTop(w), SVG.getRightAndBottom(w, h, true, 0), "Z"],
-      })
-    )
+    return SVG.path({
+      ...props,
+      path: [SVG.getTop(w), SVG.getRightAndBottom(w, h, true, 0), "Z"],
+    })
   },
 
   capPath(w, h) {
@@ -349,32 +309,27 @@ export default SVG = {
   },
 
   capRect(w, h, props) {
-    return SVG.path(
-      extend(props, {
-        path: SVG.capPath(w, h),
-      })
-    )
+    return SVG.path({ ...props, path: SVG.capPath(w, h) })
   },
 
   hatRect(w, h, props) {
-    return SVG.path(
-      extend(props, {
-        path: [
-          "M",
-          0,
-          12,
-          SVG.arc(0, 12, 80, 10, 80, 80),
-          "L",
-          w - 3,
-          10,
-          "L",
-          w,
-          10 + 3,
-          SVG.getRightAndBottom(w, h, true),
-          "Z",
-        ],
-      })
-    )
+    return SVG.path({
+      ...props,
+      path: [
+        "M",
+        0,
+        12,
+        SVG.arc(0, 12, 80, 10, 80, 80),
+        "L",
+        w - 3,
+        10,
+        "L",
+        w,
+        10 + 3,
+        SVG.getRightAndBottom(w, h, true),
+        "Z",
+      ],
+    })
   },
 
   curve(p1x, p1y, p2x, p2y, roundness) {
@@ -389,30 +344,29 @@ export default SVG = {
   procHatBase(w, h, archRoundness, props) {
     // TODO use arc()
     var archRoundness = Math.min(0.2, 35 / w)
-    return SVG.path(
-      extend(props, {
-        path: [
-          "M",
-          0,
-          15,
-          "Q",
-          SVG.curve(0, 15, w, 15, archRoundness),
-          SVG.getRightAndBottom(w, h, true),
-          "M",
-          -1,
-          13,
-          "Q",
-          SVG.curve(-1, 13, w + 1, 13, archRoundness),
-          "Q",
-          SVG.curve(w + 1, 13, w, 16, 0.6),
-          "Q",
-          SVG.curve(w, 16, 0, 16, -archRoundness),
-          "Q",
-          SVG.curve(0, 16, -1, 13, 0.6),
-          "Z",
-        ],
-      })
-    )
+    return SVG.path({
+      ...props,
+      path: [
+        "M",
+        0,
+        15,
+        "Q",
+        SVG.curve(0, 15, w, 15, archRoundness),
+        SVG.getRightAndBottom(w, h, true),
+        "M",
+        -1,
+        13,
+        "Q",
+        SVG.curve(-1, 13, w + 1, 13, archRoundness),
+        "Q",
+        SVG.curve(w + 1, 13, w, 16, 0.6),
+        "Q",
+        SVG.curve(w, 16, 0, 16, -archRoundness),
+        "Q",
+        SVG.curve(0, 16, -1, 13, 0.6),
+        "Z",
+      ],
+    })
   },
 
   procHatCap(w, h, archRoundness) {
@@ -467,11 +421,7 @@ export default SVG = {
       y += lines[i + 1].height + 3
       p.push(SVG.getRightAndBottom(w, y, hasNotch, inset))
     }
-    return SVG.path(
-      extend(props, {
-        path: p,
-      })
-    )
+    return SVG.path({ ...props, path: p })
   },
 
   ringRect(w, h, cy, cw, ch, shape, props) {
@@ -482,63 +432,54 @@ export default SVG = {
         : shape === "boolean"
         ? SVG.pointedPath
         : SVG.capPath
-    return SVG.path(
-      extend(props, {
-        path: [
-          "M",
-          r,
-          0,
-          SVG.arcw(r, 0, 0, r, r, r),
-          SVG.arcw(0, h - r, r, h, r, r),
-          SVG.arcw(w - r, h, w, h - r, r, r),
-          SVG.arcw(w, r, w - r, 0, r, r),
-          "Z",
-          SVG.translatePath(4, cy || 4, func(cw, ch).join(" ")),
-        ],
-        "fill-rule": "even-odd",
-      })
-    )
+    return SVG.path({
+      ...props,
+      path: [
+        "M",
+        r,
+        0,
+        SVG.arcw(r, 0, 0, r, r, r),
+        SVG.arcw(0, h - r, r, h, r, r),
+        SVG.arcw(w - r, h, w, h - r, r, r),
+        SVG.arcw(w, r, w - r, 0, r, r),
+        "Z",
+        SVG.translatePath(4, cy || 4, func(cw, ch).join(" ")),
+      ],
+      "fill-rule": "even-odd",
+    })
   },
 
   commentRect(w, h, props) {
     var r = 6
-    return SVG.path(
-      extend(props, {
-        class: "sb-comment",
-        path: [
-          "M",
-          r,
-          0,
-          SVG.arc(w - r, 0, w, r, r, r),
-          SVG.arc(w, h - r, w - r, h, r, r),
-          SVG.arc(r, h, 0, h - r, r, r),
-          SVG.arc(0, r, r, 0, r, r),
-          "Z",
-        ],
-      })
-    )
+    return SVG.path({
+      ...props,
+      class: "sb-comment",
+      path: [
+        "M",
+        r,
+        0,
+        SVG.arc(w - r, 0, w, r, r, r),
+        SVG.arc(w, h - r, w - r, h, r, r),
+        SVG.arc(r, h, 0, h - r, r, r),
+        SVG.arc(0, r, r, 0, r, r),
+        "Z",
+      ],
+    })
   },
 
   commentLine(width, props) {
     return SVG.move(
       -width,
       9,
-      SVG.rect(
-        width,
-        2,
-        extend(props, {
-          class: "sb-comment-line",
-        })
-      )
+      SVG.rect(width, 2, { ...props, class: "sb-comment-line" })
     )
   },
 
   strikethroughLine(w, props) {
-    return SVG.path(
-      extend(props, {
-        path: ["M", 0, 0, "L", w, 0],
-        class: "sb-diff sb-diff-del",
-      })
-    )
+    return SVG.path({
+      ...props,
+      path: ["M", 0, 0, "L", w, 0],
+      class: "sb-diff sb-diff-del",
+    })
   },
 }

--- a/scratch2/filter.js
+++ b/scratch2/filter.js
@@ -4,84 +4,93 @@ function extend(src, dest) {
 
 import SVG from "./draw.js"
 
-var Filter
-export default Filter = function (id, props) {
-  this.el = SVG.el(
-    "filter",
-    extend(props, {
-      id: id,
-      x0: "-50%",
-      y0: "-50%",
-      width: "200%",
-      height: "200%",
-    })
-  )
-  this.highestId = 0
-}
-Filter.prototype.fe = function (name, props, children) {
-  var shortName = name.toLowerCase().replace(/gaussian|osite/, "")
-  var id = [shortName, "-", ++this.highestId].join("")
-  this.el.appendChild(
-    SVG.withChildren(
-      SVG.el(
-        "fe" + name,
-        extend(props, {
-          result: id,
-        })
-      ),
-      children || []
-    )
-  )
-  return id
-}
-Filter.prototype.comp = function (op, in1, in2, props) {
-  return this.fe(
-    "Composite",
-    extend(props, {
-      operator: op,
-      in: in1,
-      in2: in2,
-    })
-  )
-}
-Filter.prototype.subtract = function (in1, in2) {
-  return this.comp("arithmetic", in1, in2, { k2: +1, k3: -1 })
-}
-Filter.prototype.offset = function (dx, dy, in1) {
-  return this.fe("Offset", {
-    in: in1,
-    dx: dx,
-    dy: dy,
-  })
-}
-Filter.prototype.flood = function (color, opacity, in1) {
-  return this.fe("Flood", {
-    in: in1,
-    "flood-color": color,
-    "flood-opacity": opacity,
-  })
-}
-Filter.prototype.blur = function (dev, in1) {
-  return this.fe("GaussianBlur", {
-    in: in1,
-    stdDeviation: [dev, dev].join(" "),
-  })
-}
-Filter.prototype.colorMatrix = function (in1, values) {
-  return this.fe("ColorMatrix", {
-    in: in1,
-    type: "matrix",
-    values: values.join(" "),
-  })
-}
-Filter.prototype.merge = function (children) {
-  this.fe(
-    "Merge",
-    {},
-    children.map(function (name) {
-      return SVG.el("feMergeNode", {
-        in: name,
+export class Filter {
+  constructor(id, props) {
+    this.el = SVG.el(
+      "filter",
+      extend(props, {
+        id: id,
+        x0: "-50%",
+        y0: "-50%",
+        width: "200%",
+        height: "200%",
       })
+    )
+    this.highestId = 0
+  }
+
+  fe(name, props, children) {
+    var shortName = name.toLowerCase().replace(/gaussian|osite/, "")
+    var id = [shortName, "-", ++this.highestId].join("")
+    this.el.appendChild(
+      SVG.withChildren(
+        SVG.el(
+          "fe" + name,
+          extend(props, {
+            result: id,
+          })
+        ),
+        children || []
+      )
+    )
+    return id
+  }
+
+  comp(op, in1, in2, props) {
+    return this.fe(
+      "Composite",
+      extend(props, {
+        operator: op,
+        in: in1,
+        in2: in2,
+      })
+    )
+  }
+
+  subtract(in1, in2) {
+    return this.comp("arithmetic", in1, in2, { k2: +1, k3: -1 })
+  }
+
+  offset(dx, dy, in1) {
+    return this.fe("Offset", {
+      in: in1,
+      dx: dx,
+      dy: dy,
     })
-  )
+  }
+
+  flood(color, opacity, in1) {
+    return this.fe("Flood", {
+      in: in1,
+      "flood-color": color,
+      "flood-opacity": opacity,
+    })
+  }
+
+  blur(dev, in1) {
+    return this.fe("GaussianBlur", {
+      in: in1,
+      stdDeviation: [dev, dev].join(" "),
+    })
+  }
+
+  colorMatrix(in1, values) {
+    return this.fe("ColorMatrix", {
+      in: in1,
+      type: "matrix",
+      values: values.join(" "),
+    })
+  }
+
+  merge(children) {
+    this.fe(
+      "Merge",
+      {},
+      children.map(function (name) {
+        return SVG.el("feMergeNode", {
+          in: name,
+        })
+      })
+    )
+  }
 }

--- a/scratch2/filter.js
+++ b/scratch2/filter.js
@@ -19,8 +19,8 @@ export default class Filter {
     this.el.appendChild(
       SVG.withChildren(
         SVG.el("fe" + name, { ...props, result: id }),
-        children || []
-      )
+        children || [],
+      ),
     )
     return id
   }
@@ -72,7 +72,7 @@ export default class Filter {
         return SVG.el("feMergeNode", {
           in: name,
         })
-      })
+      }),
     )
   }
 }

--- a/scratch2/filter.js
+++ b/scratch2/filter.js
@@ -1,21 +1,15 @@
-function extend(src, dest) {
-  return Object.assign({}, src, dest)
-}
-
 import SVG from "./draw.js"
 
 export default class Filter {
   constructor(id, props) {
-    this.el = SVG.el(
-      "filter",
-      extend(props, {
-        id: id,
-        x0: "-50%",
-        y0: "-50%",
-        width: "200%",
-        height: "200%",
-      })
-    )
+    this.el = SVG.el("filter", {
+      ...props,
+      id: id,
+      x0: "-50%",
+      y0: "-50%",
+      width: "200%",
+      height: "200%",
+    })
     this.highestId = 0
   }
 
@@ -24,12 +18,7 @@ export default class Filter {
     var id = [shortName, "-", ++this.highestId].join("")
     this.el.appendChild(
       SVG.withChildren(
-        SVG.el(
-          "fe" + name,
-          extend(props, {
-            result: id,
-          })
-        ),
+        SVG.el("fe" + name, { ...props, result: id }),
         children || []
       )
     )
@@ -37,14 +26,7 @@ export default class Filter {
   }
 
   comp(op, in1, in2, props) {
-    return this.fe(
-      "Composite",
-      extend(props, {
-        operator: op,
-        in: in1,
-        in2: in2,
-      })
-    )
+    return this.fe("Composite", { ...props, operator: op, in: in1, in2: in2 })
   }
 
   subtract(in1, in2) {

--- a/scratch2/filter.js
+++ b/scratch2/filter.js
@@ -4,7 +4,7 @@ function extend(src, dest) {
 
 import SVG from "./draw.js"
 
-export class Filter {
+export default class Filter {
   constructor(id, props) {
     this.el = SVG.el(
       "filter",

--- a/scratch2/style.js
+++ b/scratch2/style.js
@@ -53,12 +53,12 @@ export default Style = {
               d: "M8 0l2 -2l0 -3l3 0l-4 -5l-4 5l3 0l0 3l-8 0l0 2",
               fill: "#fff",
               opacity: "0.9",
-            })
+            }),
           ),
         ]),
         {
           id: "loopArrow",
-        }
+        },
       ),
       SVG.setProps(
         SVG.group([
@@ -150,7 +150,7 @@ export default Style = {
         ]),
         {
           id: "list",
-        }
+        },
       ),
     ]
   },
@@ -173,12 +173,12 @@ export default Style = {
       f.comp(
         "in",
         f.flood("#fff", 0.15),
-        f.subtract(alpha, f.offset(+s, +s, blur))
+        f.subtract(alpha, f.offset(+s, +s, blur)),
       ),
       f.comp(
         "in",
         f.flood("#000", 0.7),
-        f.subtract(alpha, f.offset(-s, -s, blur))
+        f.subtract(alpha, f.offset(-s, -s, blur)),
       ),
     ])
 
@@ -203,7 +203,7 @@ export default Style = {
           class: ["sb-" + category, "sb-darker"].join(" "),
         }),
       ]),
-      { width: w, height: h }
+      { width: w, height: h },
     )
   },
 

--- a/scratch3/blocks.js
+++ b/scratch3/blocks.js
@@ -24,7 +24,10 @@ export class LabelView {
     this.metrics = null
     this.x = 0
   }
-  isLabel = true
+
+  get isLabel() {
+    return true
+  }
 
   draw() {
     return this.el
@@ -33,9 +36,6 @@ export class LabelView {
   get width() {
     return this.metrics.width
   }
-
-  static metricsCache = {}
-  static toMeasure = []
 
   measure() {
     var value = this.value
@@ -67,6 +67,9 @@ export class LabelView {
   }
 }
 
+LabelView.metricsCache = {}
+LabelView.toMeasure = []
+
 export class IconView {
   constructor(icon) {
     Object.assign(this, icon)
@@ -77,7 +80,10 @@ export class IconView {
     }
     Object.assign(this, info)
   }
-  isIcon = true
+
+  get isIcon() {
+    return true
+  }
 
   draw() {
     return SVG.symbol("#sb3-" + this.name, {
@@ -86,26 +92,28 @@ export class IconView {
     })
   }
 
-  static icons = {
-    greenFlag: { width: 20, height: 21, dy: -2 },
-    stopSign: { width: 20, height: 20 },
-    turnLeft: { width: 24, height: 24 },
-    turnRight: { width: 24, height: 24 },
-    loopArrow: { width: 24, height: 24 },
-    addInput: { width: 4, height: 8 },
-    delInput: { width: 4, height: 8 },
-    list: { width: 15, height: 18 },
-    musicBlock: { width: 40, height: 40 },
-    penBlock: { width: 40, height: 40 },
-    videoBlock: { width: 40, height: 40, dy: 10 },
-    ttsBlock: { width: 40, height: 40 },
-    translateBlock: { width: 40, height: 40 },
-    wedoBlock: { width: 40, height: 40 },
-    ev3Block: { width: 40, height: 40 },
-    microbitBlock: { width: 40, height: 40 },
-    makeymakeyBlock: { width: 40, height: 40 },
-    gdxforBlock: { width: 40, height: 40 },
-    boostBlock: { width: 40, height: 40 },
+  static get icons() {
+    return {
+      greenFlag: { width: 20, height: 21, dy: -2 },
+      stopSign: { width: 20, height: 20 },
+      turnLeft: { width: 24, height: 24 },
+      turnRight: { width: 24, height: 24 },
+      loopArrow: { width: 24, height: 24 },
+      addInput: { width: 4, height: 8 },
+      delInput: { width: 4, height: 8 },
+      list: { width: 15, height: 18 },
+      musicBlock: { width: 40, height: 40 },
+      penBlock: { width: 40, height: 40 },
+      videoBlock: { width: 40, height: 40, dy: 10 },
+      ttsBlock: { width: 40, height: 40 },
+      translateBlock: { width: 40, height: 40 },
+      wedoBlock: { width: 40, height: 40 },
+      ev3Block: { width: 40, height: 40 },
+      microbitBlock: { width: 40, height: 40 },
+      makeymakeyBlock: { width: 40, height: 40 },
+      gdxforBlock: { width: 40, height: 40 },
+      boostBlock: { width: 40, height: 40 },
+    }
   }
 }
 
@@ -115,7 +123,10 @@ export class LineView {
     this.height = 40
     this.x = 0
   }
-  isLine = true
+
+  get isLine() {
+    return true
+  }
 
   measure = () => {}
 
@@ -144,22 +155,27 @@ export class InputView {
 
     this.x = 0
   }
-  isInput = true
+
+  get isInput() {
+    return true
+  }
 
   measure() {
     if (this.hasLabel) this.label.measure()
   }
 
-  static shapes = {
-    string: SVG.pillRect,
-    number: SVG.pillRect,
-    "number-dropdown": SVG.pillRect,
-    color: SVG.pillRect,
-    dropdown: SVG.roundRect,
+  static get shapes() {
+    return {
+      string: SVG.pillRect,
+      number: SVG.pillRect,
+      "number-dropdown": SVG.pillRect,
+      color: SVG.pillRect,
+      dropdown: SVG.roundRect,
 
-    boolean: SVG.pointedRect,
-    stack: SVG.stackRect,
-    reporter: SVG.pillRect,
+      boolean: SVG.pointedRect,
+      stack: SVG.stackRect,
+      reporter: SVG.pillRect,
+    }
   }
 
   draw(parent) {
@@ -265,7 +281,10 @@ class BlockView {
     this.firstLine = null
     this.innerWidth = null
   }
-  isBlock = true
+
+  get isBlock() {
+    return true
+  }
 
   measure() {
     for (var i = 0; i < this.children.length; i++) {
@@ -275,20 +294,22 @@ class BlockView {
     if (this.comment) this.comment.measure()
   }
 
-  static shapes = {
-    stack: SVG.stackRect,
-    "c-block": SVG.stackRect,
-    "if-block": SVG.stackRect,
-    celse: SVG.stackRect,
-    cend: SVG.stackRect,
+  static get shapes() {
+    return {
+      stack: SVG.stackRect,
+      "c-block": SVG.stackRect,
+      "if-block": SVG.stackRect,
+      celse: SVG.stackRect,
+      cend: SVG.stackRect,
 
-    cap: SVG.capRect,
-    reporter: SVG.pillRect,
-    boolean: SVG.pointedRect,
-    hat: SVG.hatRect,
-    cat: SVG.catHat,
-    "define-hat": SVG.procHatRect,
-    ring: SVG.pillRect,
+      cap: SVG.capRect,
+      reporter: SVG.pillRect,
+      boolean: SVG.pointedRect,
+      hat: SVG.hatRect,
+      cat: SVG.catHat,
+      "define-hat": SVG.procHatRect,
+      ring: SVG.pillRect,
+    }
   }
 
   drawSelf(w, h, lines) {
@@ -333,11 +354,13 @@ class BlockView {
     })
   }
 
-  static padding = {
-    hat: [24, 8],
-    cat: [24, 8],
-    "define-hat": [20, 16],
-    null: [4, 4],
+  static get padding() {
+    return {
+      hat: [24, 8],
+      cat: [24, 8],
+      "define-hat": [20, 16],
+      null: [4, 4],
+    }
   }
 
   horizontalPadding(child) {
@@ -588,10 +611,18 @@ export class CommentView {
 
     this.width = null
   }
-  isComment = true
 
-  static lineLength = 12
-  height = 20
+  get isComment() {
+    return true
+  }
+
+  static get lineLength() {
+    return 12
+  }
+
+  get height() {
+    return 20
+  }
 
   measure() {
     this.label.measure()
@@ -620,7 +651,10 @@ class GlowView {
     this.height = null
     this.y = 0
   }
-  isGlow = true
+
+  get isGlow() {
+    return true
+  }
 
   measure() {
     this.child.measure()
@@ -667,7 +701,10 @@ class ScriptView {
 
     this.y = 0
   }
-  isScript = true
+
+  get isScript() {
+    return true
+  }
 
   measure() {
     for (var i = 0; i < this.blocks.length; i++) {

--- a/scratch3/blocks.js
+++ b/scratch3/blocks.js
@@ -232,7 +232,7 @@ export class InputView {
     }
     if (this.hasArrow) {
       result.appendChild(
-        SVG.move(w - 24, 13, SVG.symbol("#sb3-dropdownArrow", {}))
+        SVG.move(w - 24, 13, SVG.symbol("#sb3-dropdownArrow", {})),
       )
     }
     return result
@@ -254,7 +254,7 @@ class BlockView {
     if (extensions.hasOwnProperty(this.info.category)) {
       this.children.unshift(new LineView())
       this.children.unshift(
-        new IconView({ name: this.info.category + "Block" })
+        new IconView({ name: this.info.category + "Block" }),
       )
       this.info.category = "extension"
     }
@@ -511,7 +511,7 @@ class BlockView {
         : this.isReporter
         ? 48
         : 0,
-      innerWidth
+      innerWidth,
     )
 
     // Center the label text inside small reporters.

--- a/scratch3/blocks.js
+++ b/scratch3/blocks.js
@@ -15,811 +15,811 @@ import SVG from "./draw.js"
 import style from "./style.js"
 const { defaultFont, commentFont, makeStyle, makeIcons } = style
 
-/* Label */
+export class LabelView {
+  constructor(label) {
+    Object.assign(this, label)
 
-export var LabelView = function (label) {
-  Object.assign(this, label)
+    this.el = null
+    this.height = 12
+    this.metrics = null
+    this.x = 0
+  }
+  isLabel = true
 
-  this.el = null
-  this.height = 12
-  this.metrics = null
-  this.x = 0
-}
-LabelView.prototype.isLabel = true
+  draw() {
+    return this.el
+  }
 
-LabelView.prototype.draw = function () {
-  return this.el
-}
-
-Object.defineProperty(LabelView.prototype, "width", {
-  get: function () {
+  get width() {
     return this.metrics.width
-  },
-})
-
-LabelView.metricsCache = {}
-LabelView.toMeasure = []
-
-LabelView.prototype.measure = function () {
-  var value = this.value
-  var cls = "sb3-" + this.cls
-  this.el = SVG.text(0, 13, value, {
-    class: "sb3-label " + cls,
-  })
-
-  var cache = LabelView.metricsCache[cls]
-  if (!cache) {
-    cache = LabelView.metricsCache[cls] = Object.create(null)
   }
 
-  if (Object.hasOwnProperty.call(cache, value)) {
-    this.metrics = cache[value]
-  } else {
-    var font = /comment-label/.test(this.cls) ? commentFont : defaultFont
-    this.metrics = cache[value] = LabelView.measure(value, font)
-    // TODO: word-spacing? (fortunately it seems to have no effect!)
-  }
-}
+  static metricsCache = {}
+  static toMeasure = []
 
-LabelView.measure = function (value, font) {
-  var context = LabelView.measuring
-  context.font = font
-  var textMetrics = context.measureText(value)
-  var width = (textMetrics.width + 0.5) | 0
-  return { width: width }
-}
-
-/* Icon */
-
-var IconView = function (icon) {
-  Object.assign(this, icon)
-
-  const info = IconView.icons[this.name]
-  if (!info) {
-    throw new Error("no info for icon: " + this.name)
-  }
-  Object.assign(this, info)
-}
-IconView.prototype.isIcon = true
-
-IconView.prototype.draw = function () {
-  return SVG.symbol("#sb3-" + this.name, {
-    width: this.width,
-    height: this.height,
-  })
-}
-
-IconView.icons = {
-  greenFlag: { width: 20, height: 21, dy: -2 },
-  stopSign: { width: 20, height: 20 },
-  turnLeft: { width: 24, height: 24 },
-  turnRight: { width: 24, height: 24 },
-  loopArrow: { width: 24, height: 24 },
-  addInput: { width: 4, height: 8 },
-  delInput: { width: 4, height: 8 },
-  list: { width: 15, height: 18 },
-  musicBlock: { width: 40, height: 40 },
-  penBlock: { width: 40, height: 40 },
-  videoBlock: { width: 40, height: 40, dy: 10 },
-  ttsBlock: { width: 40, height: 40 },
-  translateBlock: { width: 40, height: 40 },
-  wedoBlock: { width: 40, height: 40 },
-  ev3Block: { width: 40, height: 40 },
-  microbitBlock: { width: 40, height: 40 },
-  makeymakeyBlock: { width: 40, height: 40 },
-  gdxforBlock: { width: 40, height: 40 },
-  boostBlock: { width: 40, height: 40 },
-}
-
-/* Line */
-
-var LineView = function () {
-  this.width = 1
-  this.height = 40
-  this.x = 0
-}
-LineView.prototype.isLine = true
-
-LineView.prototype.measure = function () {}
-
-LineView.prototype.draw = function (parent) {
-  var category = parent.info.category
-  return SVG.el("line", {
-    class: "sb3-" + category + "-line",
-    "stroke-linecap": "round",
-    x1: 0,
-    y1: 0,
-    x2: 0,
-    y2: 40,
-  })
-}
-
-/* Input */
-
-var InputView = function (input) {
-  Object.assign(this, input)
-  if (input.label) {
-    this.label = newView(input.label)
-  }
-  this.isBoolean = this.shape === "boolean"
-  this.isDropdown = this.shape === "dropdown"
-  this.isRound = !(this.isBoolean || this.isDropdown)
-
-  this.x = 0
-}
-InputView.prototype.isInput = true
-
-InputView.prototype.measure = function () {
-  if (this.hasLabel) this.label.measure()
-}
-
-InputView.shapes = {
-  string: SVG.pillRect,
-  number: SVG.pillRect,
-  "number-dropdown": SVG.pillRect,
-  color: SVG.pillRect,
-  dropdown: SVG.roundRect,
-
-  boolean: SVG.pointedRect,
-  stack: SVG.stackRect,
-  reporter: SVG.pillRect,
-}
-
-InputView.prototype.draw = function (parent) {
-  var labelX = 11
-  if (this.isBoolean) {
-    var w = 48
-  } else if (this.isColor) {
-    var w = 40
-  } else if (this.hasLabel) {
-    var label = this.label.draw()
-    // Minimum padding of 11
-    // Minimum width of 40, at which point we center the label
-    var px = this.label.width >= 18 ? 11 : (40 - this.label.width) / 2
-    var w = this.label.width + 2 * px
-    label = SVG.move(px, 9, label)
-  } else {
-    var w = this.isInset ? 30 : null
-  }
-  if (this.hasArrow) w += 20
-  this.width = w
-
-  var h = (this.height = 32)
-
-  var el = InputView.shapes[this.shape](w, h)
-  SVG.setProps(el, {
-    class: [
-      this.isColor ? "" : "sb3-" + parent.info.category,
-      "sb3-input",
-      "sb3-input-" + this.shape,
-    ].join(" "),
-  })
-
-  if (this.isColor) {
-    SVG.setProps(el, {
-      fill: this.value,
+  measure() {
+    var value = this.value
+    var cls = "sb3-" + this.cls
+    this.el = SVG.text(0, 13, value, {
+      class: "sb3-label " + cls,
     })
-  } else if (this.shape === "dropdown") {
-    // custom colors
-    if (parent.info.color) {
-      SVG.setProps(el, {
-        fill: parent.info.color,
-        stroke: "rgba(0, 0, 0, 0.2)",
-      })
-    }
-  } else if (this.shape === "number-dropdown") {
-    el.classList.add("sb3-" + parent.info.category + "-alt")
 
-    // custom colors
-    if (parent.info.color) {
-      SVG.setProps(el, {
-        fill: "rgba(0, 0, 0, 0.1)",
-        stroke: "rgba(0, 0, 0, 0.15)", // combines with fill...
-      })
+    var cache = LabelView.metricsCache[cls]
+    if (!cache) {
+      cache = LabelView.metricsCache[cls] = Object.create(null)
     }
-  } else if (this.shape === "boolean") {
-    el.classList.remove("sb3-" + parent.info.category)
-    el.classList.add("sb3-" + parent.info.category + "-dark")
 
-    // custom colors
-    if (parent.info.color) {
-      SVG.setProps(el, {
-        fill: "rgba(0, 0, 0, 0.15)",
-      })
+    if (Object.hasOwnProperty.call(cache, value)) {
+      this.metrics = cache[value]
+    } else {
+      var font = /comment-label/.test(this.cls) ? commentFont : defaultFont
+      this.metrics = cache[value] = LabelView.measure(value, font)
+      // TODO: word-spacing? (fortunately it seems to have no effect!)
     }
   }
 
-  var result = SVG.group([el])
-  if (this.hasLabel) {
-    result.appendChild(label)
+  static measure = function (value, font) {
+    var context = LabelView.measuring
+    context.font = font
+    var textMetrics = context.measureText(value)
+    var width = (textMetrics.width + 0.5) | 0
+    return { width: width }
   }
-  if (this.hasArrow) {
-    result.appendChild(
-      SVG.move(w - 24, 13, SVG.symbol("#sb3-dropdownArrow", {}))
-    )
-  }
-  return result
 }
 
-/* Block */
+export class IconView {
+  constructor(icon) {
+    Object.assign(this, icon)
 
-var BlockView = function (block) {
-  Object.assign(this, block)
-  this.children = block.children.map(newView)
-  this.comment = this.comment ? newView(this.comment) : null
-  this.isRound = this.isReporter
-
-  // Avoid accidental mutation
-  this.info = Object.assign({}, block.info)
-  if (aliasExtensions.hasOwnProperty(this.info.category)) {
-    this.info.category = aliasExtensions[this.info.category]
+    const info = IconView.icons[this.name]
+    if (!info) {
+      throw new Error("no info for icon: " + this.name)
+    }
+    Object.assign(this, info)
   }
-  if (extensions.hasOwnProperty(this.info.category)) {
-    this.children.unshift(new LineView())
-    this.children.unshift(new IconView({ name: this.info.category + "Block" }))
-    this.info.category = "extension"
+  isIcon = true
+
+  draw() {
+    return SVG.symbol("#sb3-" + this.name, {
+      width: this.width,
+      height: this.height,
+    })
   }
 
-  this.x = 0
-  this.width = null
-  this.height = null
-  this.firstLine = null
-  this.innerWidth = null
-}
-BlockView.prototype.isBlock = true
-
-BlockView.prototype.measure = function () {
-  for (var i = 0; i < this.children.length; i++) {
-    var child = this.children[i]
-    if (child.measure) child.measure()
+  static icons = {
+    greenFlag: { width: 20, height: 21, dy: -2 },
+    stopSign: { width: 20, height: 20 },
+    turnLeft: { width: 24, height: 24 },
+    turnRight: { width: 24, height: 24 },
+    loopArrow: { width: 24, height: 24 },
+    addInput: { width: 4, height: 8 },
+    delInput: { width: 4, height: 8 },
+    list: { width: 15, height: 18 },
+    musicBlock: { width: 40, height: 40 },
+    penBlock: { width: 40, height: 40 },
+    videoBlock: { width: 40, height: 40, dy: 10 },
+    ttsBlock: { width: 40, height: 40 },
+    translateBlock: { width: 40, height: 40 },
+    wedoBlock: { width: 40, height: 40 },
+    ev3Block: { width: 40, height: 40 },
+    microbitBlock: { width: 40, height: 40 },
+    makeymakeyBlock: { width: 40, height: 40 },
+    gdxforBlock: { width: 40, height: 40 },
+    boostBlock: { width: 40, height: 40 },
   }
-  if (this.comment) this.comment.measure()
-}
-
-BlockView.shapes = {
-  stack: SVG.stackRect,
-  "c-block": SVG.stackRect,
-  "if-block": SVG.stackRect,
-  celse: SVG.stackRect,
-  cend: SVG.stackRect,
-
-  cap: SVG.capRect,
-  reporter: SVG.pillRect,
-  boolean: SVG.pointedRect,
-  hat: SVG.hatRect,
-  cat: SVG.catHat,
-  "define-hat": SVG.procHatRect,
-  ring: SVG.pillRect,
 }
 
-BlockView.prototype.drawSelf = function (w, h, lines) {
-  // mouths
-  if (lines.length > 1) {
-    return SVG.mouthRect(w, h, this.isFinal, lines, {
+export class LineView {
+  constructor() {
+    this.width = 1
+    this.height = 40
+    this.x = 0
+  }
+  isLine = true
+
+  measure = () => {}
+
+  draw(parent) {
+    var category = parent.info.category
+    return SVG.el("line", {
+      class: "sb3-" + category + "-line",
+      "stroke-linecap": "round",
+      x1: 0,
+      y1: 0,
+      x2: 0,
+      y2: 40,
+    })
+  }
+}
+
+export class InputView {
+  constructor(input) {
+    Object.assign(this, input)
+    if (input.label) {
+      this.label = newView(input.label)
+    }
+    this.isBoolean = this.shape === "boolean"
+    this.isDropdown = this.shape === "dropdown"
+    this.isRound = !(this.isBoolean || this.isDropdown)
+
+    this.x = 0
+  }
+  isInput = true
+
+  measure() {
+    if (this.hasLabel) this.label.measure()
+  }
+
+  static shapes = {
+    string: SVG.pillRect,
+    number: SVG.pillRect,
+    "number-dropdown": SVG.pillRect,
+    color: SVG.pillRect,
+    dropdown: SVG.roundRect,
+
+    boolean: SVG.pointedRect,
+    stack: SVG.stackRect,
+    reporter: SVG.pillRect,
+  }
+
+  draw(parent) {
+    var labelX = 11
+    if (this.isBoolean) {
+      var w = 48
+    } else if (this.isColor) {
+      var w = 40
+    } else if (this.hasLabel) {
+      var label = this.label.draw()
+      // Minimum padding of 11
+      // Minimum width of 40, at which point we center the label
+      var px = this.label.width >= 18 ? 11 : (40 - this.label.width) / 2
+      var w = this.label.width + 2 * px
+      label = SVG.move(px, 9, label)
+    } else {
+      var w = this.isInset ? 30 : null
+    }
+    if (this.hasArrow) w += 20
+    this.width = w
+
+    var h = (this.height = 32)
+
+    var el = InputView.shapes[this.shape](w, h)
+    SVG.setProps(el, {
+      class: [
+        this.isColor ? "" : "sb3-" + parent.info.category,
+        "sb3-input",
+        "sb3-input-" + this.shape,
+      ].join(" "),
+    })
+
+    if (this.isColor) {
+      SVG.setProps(el, {
+        fill: this.value,
+      })
+    } else if (this.shape === "dropdown") {
+      // custom colors
+      if (parent.info.color) {
+        SVG.setProps(el, {
+          fill: parent.info.color,
+          stroke: "rgba(0, 0, 0, 0.2)",
+        })
+      }
+    } else if (this.shape === "number-dropdown") {
+      el.classList.add("sb3-" + parent.info.category + "-alt")
+
+      // custom colors
+      if (parent.info.color) {
+        SVG.setProps(el, {
+          fill: "rgba(0, 0, 0, 0.1)",
+          stroke: "rgba(0, 0, 0, 0.15)", // combines with fill...
+        })
+      }
+    } else if (this.shape === "boolean") {
+      el.classList.remove("sb3-" + parent.info.category)
+      el.classList.add("sb3-" + parent.info.category + "-dark")
+
+      // custom colors
+      if (parent.info.color) {
+        SVG.setProps(el, {
+          fill: "rgba(0, 0, 0, 0.15)",
+        })
+      }
+    }
+
+    var result = SVG.group([el])
+    if (this.hasLabel) {
+      result.appendChild(label)
+    }
+    if (this.hasArrow) {
+      result.appendChild(
+        SVG.move(w - 24, 13, SVG.symbol("#sb3-dropdownArrow", {}))
+      )
+    }
+    return result
+  }
+}
+
+class BlockView {
+  constructor(block) {
+    Object.assign(this, block)
+    this.children = block.children.map(newView)
+    this.comment = this.comment ? newView(this.comment) : null
+    this.isRound = this.isReporter
+
+    // Avoid accidental mutation
+    this.info = Object.assign({}, block.info)
+    if (aliasExtensions.hasOwnProperty(this.info.category)) {
+      this.info.category = aliasExtensions[this.info.category]
+    }
+    if (extensions.hasOwnProperty(this.info.category)) {
+      this.children.unshift(new LineView())
+      this.children.unshift(
+        new IconView({ name: this.info.category + "Block" })
+      )
+      this.info.category = "extension"
+    }
+
+    this.x = 0
+    this.width = null
+    this.height = null
+    this.firstLine = null
+    this.innerWidth = null
+  }
+  isBlock = true
+
+  measure() {
+    for (var i = 0; i < this.children.length; i++) {
+      var child = this.children[i]
+      if (child.measure) child.measure()
+    }
+    if (this.comment) this.comment.measure()
+  }
+
+  static shapes = {
+    stack: SVG.stackRect,
+    "c-block": SVG.stackRect,
+    "if-block": SVG.stackRect,
+    celse: SVG.stackRect,
+    cend: SVG.stackRect,
+
+    cap: SVG.capRect,
+    reporter: SVG.pillRect,
+    boolean: SVG.pointedRect,
+    hat: SVG.hatRect,
+    cat: SVG.catHat,
+    "define-hat": SVG.procHatRect,
+    ring: SVG.pillRect,
+  }
+
+  drawSelf(w, h, lines) {
+    // mouths
+    if (lines.length > 1) {
+      return SVG.mouthRect(w, h, this.isFinal, lines, {
+        class: ["sb3-" + this.info.category].join(" "),
+      })
+    }
+
+    // outlines
+    if (this.info.shape === "outline") {
+      return SVG.setProps(SVG.stackRect(w, h), {
+        class: [
+          "sb3-" + this.info.category,
+          "sb3-" + this.info.category + "-alt",
+        ].join(" "),
+      })
+    }
+
+    // rings
+    if (this.isRing) {
+      var child = this.children[0]
+      if (child && (child.isInput || child.isBlock || child.isScript)) {
+        var shape = child.isScript
+          ? "stack"
+          : child.isInput
+          ? child.shape
+          : child.info.shape
+        return SVG.roundRect(w, h, {
+          class: ["sb3-" + this.info.category].join(" "),
+        })
+      }
+    }
+
+    var func = BlockView.shapes[this.info.shape]
+    if (!func) {
+      throw new Error("no shape func: " + this.info.shape)
+    }
+    return func(w, h, {
       class: ["sb3-" + this.info.category].join(" "),
     })
   }
 
-  // outlines
-  if (this.info.shape === "outline") {
-    return SVG.setProps(SVG.stackRect(w, h), {
-      class: [
-        "sb3-" + this.info.category,
-        "sb3-" + this.info.category + "-alt",
-      ].join(" "),
-    })
+  static padding = {
+    hat: [24, 8],
+    cat: [24, 8],
+    "define-hat": [20, 16],
+    null: [4, 4],
   }
 
-  // rings
-  if (this.isRing) {
-    var child = this.children[0]
-    if (child && (child.isInput || child.isBlock || child.isScript)) {
-      var shape = child.isScript
-        ? "stack"
-        : child.isInput
-        ? child.shape
-        : child.info.shape
-      return SVG.roundRect(w, h, {
-        class: ["sb3-" + this.info.category].join(" "),
-      })
-    }
-  }
-
-  var func = BlockView.shapes[this.info.shape]
-  if (!func) {
-    throw new Error("no shape func: " + this.info.shape)
-  }
-  return func(w, h, {
-    class: ["sb3-" + this.info.category].join(" "),
-  })
-}
-
-BlockView.padding = {
-  hat: [24, 8],
-  cat: [24, 8],
-  "define-hat": [20, 16],
-  null: [4, 4],
-}
-
-BlockView.prototype.horizontalPadding = function (child) {
-  if (this.isRound) {
-    if (child.isIcon) {
-      return 16
-    } else if (child.isLabel) {
-      return 12 // text in circle: 3 units
-    } else if (child.isDropdown) {
-      return 12 // square in circle: 3 units
-    } else if (child.isBoolean) {
-      return 12 // hexagon in circle: 3 units
-    } else if (child.isRound) {
-      return 4 // circle in circle: 1 unit
-    }
-  } else if (this.isBoolean) {
-    if (child.isIcon) {
-      return 24 // icon in hexagon: ???
-    } else if (child.isLabel) {
-      return 20 // text in hexagon: 5 units
-    } else if (child.isDropdown) {
-      return 20 // square in hexagon: 5 units
-    } else if (child.isRound && child.isBlock) {
-      return 24 // circle in hexagon: 5 + 1 units
-    } else if (child.isRound) {
-      return 20 // circle in hexagon: 5 units
-    } else if (child.isBoolean) {
-      return 8 // hexagon in hexagon: 2 units
-    }
-  }
-  return 8 // default: 2 units
-}
-
-BlockView.prototype.marginBetween = function (a, b) {
-  // Consecutive labels should be rendered as a single text element.
-  // For now, approximate the size of one space
-  if (a.isLabel && b.isLabel) {
-    return 5
-  }
-
-  return 8 // default: 2 units
-}
-
-BlockView.prototype.draw = function () {
-  var isDefine = this.info.shape === "define-hat"
-  var children = this.children
-  var isCommand = this.isCommand
-
-  var padding = BlockView.padding[this.info.shape] || BlockView.padding[null]
-  var pt = padding[0],
-    pb = padding[1]
-
-  var _this = this
-  var y = this.info.shape === "cat" ? 16 : 0
-  var Line = function (y) {
-    this.y = y
-    this.width = 0
-    this.height = isCommand ? 40 : 32
-    this.children = []
-  }
-
-  var innerWidth = 0
-  var scriptWidth = 0
-  var line = new Line(y)
-  function pushLine() {
-    if (lines.length === 0) {
-      line.height += pt + pb
-    } else {
-      line.height -= 11
-      line.y -= 2
-    }
-    y += line.height
-    lines.push(line)
-  }
-
-  if (this.info.isRTL) {
-    var start = 0
-    var flip = function () {
-      children = children
-        .slice(0, start)
-        .concat(children.slice(start, i).reverse())
-        .concat(children.slice(i))
-    }.bind(this)
-    for (var i = 0; i < children.length; i++) {
-      if (children[i].isScript) {
-        flip()
-        start = i + 1
+  horizontalPadding(child) {
+    if (this.isRound) {
+      if (child.isIcon) {
+        return 16
+      } else if (child.isLabel) {
+        return 12 // text in circle: 3 units
+      } else if (child.isDropdown) {
+        return 12 // square in circle: 3 units
+      } else if (child.isBoolean) {
+        return 12 // hexagon in circle: 3 units
+      } else if (child.isRound) {
+        return 4 // circle in circle: 1 unit
+      }
+    } else if (this.isBoolean) {
+      if (child.isIcon) {
+        return 24 // icon in hexagon: ???
+      } else if (child.isLabel) {
+        return 20 // text in hexagon: 5 units
+      } else if (child.isDropdown) {
+        return 20 // square in hexagon: 5 units
+      } else if (child.isRound && child.isBlock) {
+        return 24 // circle in hexagon: 5 + 1 units
+      } else if (child.isRound) {
+        return 20 // circle in hexagon: 5 units
+      } else if (child.isBoolean) {
+        return 8 // hexagon in hexagon: 2 units
       }
     }
-    if (start < i) {
-      flip()
-    }
+    return 8 // default: 2 units
   }
 
-  var lines = []
-  var previousChild
-  var lastChild
-  for (var i = 0; i < children.length; i++) {
-    var child = children[i]
-    child.el = child.draw(this)
+  marginBetween(a, b) {
+    // Consecutive labels should be rendered as a single text element.
+    // For now, approximate the size of one space
+    if (a.isLabel && b.isLabel) {
+      return 5
+    }
 
-    if (child.isScript && this.isCommand) {
-      this.hasScript = true
-      pushLine()
-      child.y = y - 1
-      lines.push(child)
-      scriptWidth = Math.max(scriptWidth, Math.max(1, child.width))
-      child.height = Math.max(29, child.height + 3) - 2
-      y += child.height
-      line = new Line(y)
-      previousChild = null
-    } else if (child.isArrow) {
-      line.children.push(child)
-      previousChild = child
-    } else {
-      // Remember the last child on the first line
-      if (!lines.length) {
-        lastChild = child
+    return 8 // default: 2 units
+  }
+
+  draw() {
+    var isDefine = this.info.shape === "define-hat"
+    var children = this.children
+    var isCommand = this.isCommand
+
+    var padding = BlockView.padding[this.info.shape] || BlockView.padding[null]
+    var pt = padding[0],
+      pb = padding[1]
+
+    var _this = this
+    var y = this.info.shape === "cat" ? 16 : 0
+    var Line = function (y) {
+      this.y = y
+      this.width = 0
+      this.height = isCommand ? 40 : 32
+      this.children = []
+    }
+
+    var innerWidth = 0
+    var scriptWidth = 0
+    var line = new Line(y)
+    function pushLine() {
+      if (lines.length === 0) {
+        line.height += pt + pb
+      } else {
+        line.height -= 11
+        line.y -= 2
       }
+      y += line.height
+      lines.push(line)
+    }
 
-      // Leave space between inputs
-      if (previousChild) {
-        line.width += this.marginBetween(previousChild, child)
-      }
-
-      // Align first input with right of notch
-      if (children[0] != null) {
-        var cmw = 48 - this.horizontalPadding(children[0])
-        if (
-          (this.isCommand || this.isOutline) &&
-          !child.isLabel &&
-          !child.isIcon &&
-          line.width < cmw
-        ) {
-          line.width = cmw
+    if (this.info.isRTL) {
+      var start = 0
+      var flip = function () {
+        children = children
+          .slice(0, start)
+          .concat(children.slice(start, i).reverse())
+          .concat(children.slice(i))
+      }.bind(this)
+      for (var i = 0; i < children.length; i++) {
+        if (children[i].isScript) {
+          flip()
+          start = i + 1
         }
       }
-
-      // Align extension category icons below notch
-      if (child.isIcon && i === 0 && this.isCommand) {
-        line.height = Math.max(line.height, child.height + 8)
+      if (start < i) {
+        flip()
       }
-
-      child.x = line.width
-      line.width += child.width
-      innerWidth = Math.max(innerWidth, line.width)
-      if (!child.isLabel) {
-        line.height = Math.max(line.height, child.height)
-      }
-      line.children.push(child)
-      previousChild = child
-    }
-  }
-  pushLine()
-
-  var padLeft = children.length ? this.horizontalPadding(children[0]) : 0
-  var padRight = children.length ? this.horizontalPadding(lastChild) : 0
-  innerWidth += padLeft + padRight
-
-  // Commands have a minimum width
-  // The hat min-width is arbitrary (not sure of Scratch 3 value)
-  // Outline min-width is deliberately higher (because Scratch 3 looks silly)
-  var originalInnerWidth = innerWidth
-  innerWidth = Math.max(
-    this.hasScript
-      ? 160
-      : this.isHat
-      ? 108
-      : this.isCommand || this.isOutline
-      ? 64
-      : this.isReporter
-      ? 48
-      : 0,
-    innerWidth
-  )
-
-  // Center the label text inside small reporters.
-  if (this.isReporter) {
-    padLeft += (innerWidth - originalInnerWidth) / 2
-  }
-
-  this.height = y
-
-  this.width = scriptWidth ? Math.max(innerWidth, 15 + scriptWidth) : innerWidth
-  this.firstLine = lines[0]
-  this.innerWidth = innerWidth
-
-  var objects = []
-
-  for (var i = 0; i < lines.length; i++) {
-    var line = lines[i]
-    if (line.isScript) {
-      objects.push(SVG.move(16, line.y, line.el))
-      continue
     }
 
-    var h = line.height
+    var lines = []
+    var previousChild
+    var lastChild
+    for (var i = 0; i < children.length; i++) {
+      var child = children[i]
+      child.el = child.draw(this)
 
-    for (var j = 0; j < line.children.length; j++) {
-      var child = line.children[j]
-      if (child.isArrow) {
-        objects.push(SVG.move(innerWidth - 32, this.height - 28, child.el))
+      if (child.isScript && this.isCommand) {
+        this.hasScript = true
+        pushLine()
+        child.y = y - 1
+        lines.push(child)
+        scriptWidth = Math.max(scriptWidth, Math.max(1, child.width))
+        child.height = Math.max(29, child.height + 3) - 2
+        y += child.height
+        line = new Line(y)
+        previousChild = null
+      } else if (child.isArrow) {
+        line.children.push(child)
+        previousChild = child
+      } else {
+        // Remember the last child on the first line
+        if (!lines.length) {
+          lastChild = child
+        }
+
+        // Leave space between inputs
+        if (previousChild) {
+          line.width += this.marginBetween(previousChild, child)
+        }
+
+        // Align first input with right of notch
+        if (children[0] != null) {
+          var cmw = 48 - this.horizontalPadding(children[0])
+          if (
+            (this.isCommand || this.isOutline) &&
+            !child.isLabel &&
+            !child.isIcon &&
+            line.width < cmw
+          ) {
+            line.width = cmw
+          }
+        }
+
+        // Align extension category icons below notch
+        if (child.isIcon && i === 0 && this.isCommand) {
+          line.height = Math.max(line.height, child.height + 8)
+        }
+
+        child.x = line.width
+        line.width += child.width
+        innerWidth = Math.max(innerWidth, line.width)
+        if (!child.isLabel) {
+          line.height = Math.max(line.height, child.height)
+        }
+        line.children.push(child)
+        previousChild = child
+      }
+    }
+    pushLine()
+
+    var padLeft = children.length ? this.horizontalPadding(children[0]) : 0
+    var padRight = children.length ? this.horizontalPadding(lastChild) : 0
+    innerWidth += padLeft + padRight
+
+    // Commands have a minimum width
+    // The hat min-width is arbitrary (not sure of Scratch 3 value)
+    // Outline min-width is deliberately higher (because Scratch 3 looks silly)
+    var originalInnerWidth = innerWidth
+    innerWidth = Math.max(
+      this.hasScript
+        ? 160
+        : this.isHat
+        ? 108
+        : this.isCommand || this.isOutline
+        ? 64
+        : this.isReporter
+        ? 48
+        : 0,
+      innerWidth
+    )
+
+    // Center the label text inside small reporters.
+    if (this.isReporter) {
+      padLeft += (innerWidth - originalInnerWidth) / 2
+    }
+
+    this.height = y
+
+    this.width = scriptWidth
+      ? Math.max(innerWidth, 15 + scriptWidth)
+      : innerWidth
+    this.firstLine = lines[0]
+    this.innerWidth = innerWidth
+
+    var objects = []
+
+    for (var i = 0; i < lines.length; i++) {
+      var line = lines[i]
+      if (line.isScript) {
+        objects.push(SVG.move(16, line.y, line.el))
         continue
       }
 
-      var y = pt + (h - child.height - pt - pb) / 2
-      if (child.isLabel && i === 0) {
-        // We only do this for the first line so that the `else` label is
-        // correctly aligned
-        y -= 1
-      } else if (isDefine && child.isLabel) {
-        y += 3
-      } else if (child.isIcon) {
-        y += child.dy | 0
-        if (this.isCommand && i === 0 && j === 0) {
-          y += 4
+      var h = line.height
+
+      for (var j = 0; j < line.children.length; j++) {
+        var child = line.children[j]
+        if (child.isArrow) {
+          objects.push(SVG.move(innerWidth - 32, this.height - 28, child.el))
+          continue
         }
-      }
 
-      var x = padLeft + child.x
-      if (child.dx) {
-        x += child.dx
-      }
+        var y = pt + (h - child.height - pt - pb) / 2
+        if (child.isLabel && i === 0) {
+          // We only do this for the first line so that the `else` label is
+          // correctly aligned
+          y -= 1
+        } else if (isDefine && child.isLabel) {
+          y += 3
+        } else if (child.isIcon) {
+          y += child.dy | 0
+          if (this.isCommand && i === 0 && j === 0) {
+            y += 4
+          }
+        }
 
-      objects.push(SVG.move(x, (line.y + y) | 0, child.el))
+        var x = padLeft + child.x
+        if (child.dx) {
+          x += child.dx
+        }
+
+        objects.push(SVG.move(x, (line.y + y) | 0, child.el))
+      }
+    }
+
+    var el = this.drawSelf(innerWidth, this.height, lines)
+    objects.splice(0, 0, el)
+    if (this.info.color) {
+      SVG.setProps(el, {
+        fill: this.info.color,
+        stroke: "rgba(0, 0, 0, 0.2)",
+      })
+    }
+
+    return SVG.group(objects)
+  }
+}
+
+export class CommentView {
+  constructor(comment) {
+    Object.assign(this, comment)
+    this.label = newView(comment.label)
+
+    this.width = null
+  }
+  isComment = true
+
+  static lineLength = 12
+  height = 20
+
+  measure() {
+    this.label.measure()
+  }
+
+  draw() {
+    var labelEl = this.label.draw()
+
+    this.width = this.label.width + 16
+    return SVG.group([
+      SVG.commentLine(this.hasBlock ? CommentView.lineLength : 0, 6),
+      SVG.commentRect(this.width, this.height, {
+        class: "sb3-comment",
+      }),
+      SVG.move(8, 4, labelEl),
+    ])
+  }
+}
+
+class GlowView {
+  constructor(glow) {
+    Object.assign(this, glow)
+    this.child = newView(glow.child)
+
+    this.width = null
+    this.height = null
+    this.y = 0
+  }
+  isGlow = true
+
+  measure() {
+    this.child.measure()
+  }
+
+  drawSelf() {
+    var c = this.child
+    var el
+    var w = this.width
+    var h = this.height - 1
+    if (c.isScript) {
+      if (!c.isEmpty && c.blocks[0].isHat) {
+        el = SVG.hatRect(w, h)
+      } else if (c.isFinal) {
+        el = SVG.capRect(w, h)
+      } else {
+        el = SVG.stackRect(w, h)
+      }
+    } else {
+      var el = c.drawSelf(w, h, [])
+    }
+    return SVG.setProps(el, {
+      class: "sb3-diff sb3-diff-ins",
+    })
+  }
+  // TODO how can we always raise Glows above their parents?
+
+  draw() {
+    var c = this.child
+    var el = c.isScript ? c.draw(true) : c.draw()
+
+    this.width = c.width
+    this.height = (c.isBlock && c.firstLine.height) || c.height
+
+    // encircle
+    return SVG.group([el, this.drawSelf()])
+  }
+}
+
+class ScriptView {
+  constructor(script) {
+    Object.assign(this, script)
+    this.blocks = script.blocks.map(newView)
+
+    this.y = 0
+  }
+  isScript = true
+
+  measure() {
+    for (var i = 0; i < this.blocks.length; i++) {
+      this.blocks[i].measure()
     }
   }
 
-  var el = this.drawSelf(innerWidth, this.height, lines)
-  objects.splice(0, 0, el)
-  if (this.info.color) {
-    SVG.setProps(el, {
-      fill: this.info.color,
-      stroke: "rgba(0, 0, 0, 0.2)",
+  draw(inside) {
+    var children = []
+    var y = 1
+    this.width = 0
+    for (var i = 0; i < this.blocks.length; i++) {
+      var block = this.blocks[i]
+      var x = inside ? 0 : 2
+      var child = block.draw()
+      children.push(SVG.move(x, y, child))
+      this.width = Math.max(this.width, block.width)
+
+      var diff = block.diff
+      if (diff === "-") {
+        var dw = block.width
+        var dh = block.firstLine.height || block.height
+        children.push(SVG.move(x, y + dh / 2 + 1, SVG.strikethroughLine(dw)))
+        this.width = Math.max(this.width, block.width)
+      }
+
+      y += block.height
+
+      var comment = block.comment
+      if (comment) {
+        var line = block.firstLine
+        var cx = block.innerWidth + 2 + CommentView.lineLength
+        var cy = y - block.height + line.height / 2
+        var el = comment.draw()
+        children.push(SVG.move(cx, cy - comment.height / 2, el))
+        this.width = Math.max(this.width, cx + comment.width)
+      }
+    }
+    this.height = y + 1
+    if (!inside && !this.isFinal) {
+      this.height += block.hasPuzzle ? 8 : 0
+    }
+    if (!inside && block.isGlow) {
+      this.height += 7 // TODO unbreak this
+    }
+    return SVG.group(children)
+  }
+}
+
+class DocumentView {
+  constructor(doc, options) {
+    Object.assign(this, doc)
+    this.scripts = doc.scripts.map(newView)
+
+    this.width = null
+    this.height = null
+    this.el = null
+    this.defs = null
+    this.scale = options.scale
+  }
+
+  measure() {
+    this.scripts.forEach(function (script) {
+      script.measure()
     })
   }
 
-  return SVG.group(objects)
-}
-
-/* Comment */
-
-var CommentView = function (comment) {
-  Object.assign(this, comment)
-  this.label = newView(comment.label)
-
-  this.width = null
-}
-CommentView.prototype.isComment = true
-
-CommentView.lineLength = 12
-CommentView.prototype.height = 20
-
-CommentView.prototype.measure = function () {
-  this.label.measure()
-}
-
-CommentView.prototype.draw = function () {
-  var labelEl = this.label.draw()
-
-  this.width = this.label.width + 16
-  return SVG.group([
-    SVG.commentLine(this.hasBlock ? CommentView.lineLength : 0, 6),
-    SVG.commentRect(this.width, this.height, {
-      class: "sb3-comment",
-    }),
-    SVG.move(8, 4, labelEl),
-  ])
-}
-
-/* Glow */
-
-var GlowView = function (glow) {
-  Object.assign(this, glow)
-  this.child = newView(glow.child)
-
-  this.width = null
-  this.height = null
-  this.y = 0
-}
-GlowView.prototype.isGlow = true
-
-GlowView.prototype.measure = function () {
-  this.child.measure()
-}
-
-GlowView.prototype.drawSelf = function () {
-  var c = this.child
-  var el
-  var w = this.width
-  var h = this.height - 1
-  if (c.isScript) {
-    if (!c.isEmpty && c.blocks[0].isHat) {
-      el = SVG.hatRect(w, h)
-    } else if (c.isFinal) {
-      el = SVG.capRect(w, h)
-    } else {
-      el = SVG.stackRect(w, h)
-    }
-  } else {
-    var el = c.drawSelf(w, h, [])
-  }
-  return SVG.setProps(el, {
-    class: "sb3-diff sb3-diff-ins",
-  })
-}
-// TODO how can we always raise Glows above their parents?
-
-GlowView.prototype.draw = function () {
-  var c = this.child
-  var el = c.isScript ? c.draw(true) : c.draw()
-
-  this.width = c.width
-  this.height = (c.isBlock && c.firstLine.height) || c.height
-
-  // encircle
-  return SVG.group([el, this.drawSelf()])
-}
-
-/* Script */
-
-var ScriptView = function (script) {
-  Object.assign(this, script)
-  this.blocks = script.blocks.map(newView)
-
-  this.y = 0
-}
-ScriptView.prototype.isScript = true
-
-ScriptView.prototype.measure = function () {
-  for (var i = 0; i < this.blocks.length; i++) {
-    this.blocks[i].measure()
-  }
-}
-
-ScriptView.prototype.draw = function (inside) {
-  var children = []
-  var y = 1
-  this.width = 0
-  for (var i = 0; i < this.blocks.length; i++) {
-    var block = this.blocks[i]
-    var x = inside ? 0 : 2
-    var child = block.draw()
-    children.push(SVG.move(x, y, child))
-    this.width = Math.max(this.width, block.width)
-
-    var diff = block.diff
-    if (diff === "-") {
-      var dw = block.width
-      var dh = block.firstLine.height || block.height
-      children.push(SVG.move(x, y + dh / 2 + 1, SVG.strikethroughLine(dw)))
-      this.width = Math.max(this.width, block.width)
+  render(cb) {
+    if (typeof ocbptions === "function") {
+      throw new Error("render() no longer takes a callback")
     }
 
-    y += block.height
+    // measure strings
+    this.measure()
 
-    var comment = block.comment
-    if (comment) {
-      var line = block.firstLine
-      var cx = block.innerWidth + 2 + CommentView.lineLength
-      var cy = y - block.height + line.height / 2
-      var el = comment.draw()
-      children.push(SVG.move(cx, cy - comment.height / 2, el))
-      this.width = Math.max(this.width, cx + comment.width)
+    // TODO: separate layout + render steps.
+    // render each script
+    var width = 0
+    var height = 0
+    var elements = []
+    for (var i = 0; i < this.scripts.length; i++) {
+      var script = this.scripts[i]
+      if (height) height += 10
+      script.y = height
+      elements.push(SVG.move(0, height, script.draw()))
+      height += script.height
+      if (i !== this.scripts.length - 1) height += 36
+      width = Math.max(width, script.width + 4)
+    }
+    this.width = width
+    this.height = height
+
+    // return SVG
+    var svg = SVG.newSVG(width, height, this.scale)
+    svg.appendChild((this.defs = SVG.withChildren(SVG.el("defs"), makeIcons())))
+
+    svg.appendChild(SVG.group(elements))
+    this.el = svg
+    return svg
+  }
+
+  /* Export SVG image as XML string */
+  exportSVGString() {
+    if (this.el == null) {
+      throw new Error("call draw() first")
+    }
+
+    var style = makeStyle()
+    this.defs.appendChild(style)
+    var xml = new SVG.XMLSerializer().serializeToString(this.el)
+    this.defs.removeChild(style)
+    return xml
+  }
+
+  /* Export SVG image as data URI */
+  exportSVG() {
+    var xml = this.exportSVGString()
+    return "data:image/svg+xml;utf8," + xml.replace(/[#]/g, encodeURIComponent)
+  }
+
+  toCanvas(cb, exportScale) {
+    exportScale = exportScale || 1.0
+
+    var canvas = SVG.makeCanvas()
+    canvas.width = Math.max(1, this.width * exportScale * this.scale)
+    canvas.height = Math.max(1, this.height * exportScale * this.scale)
+    var context = canvas.getContext("2d")
+
+    var image = new Image()
+    image.src = this.exportSVG()
+    image.onload = function () {
+      context.save()
+      context.scale(exportScale, exportScale)
+      context.drawImage(image, 0, 0)
+      context.restore()
+
+      cb(canvas)
     }
   }
-  this.height = y + 1
-  if (!inside && !this.isFinal) {
-    this.height += block.hasPuzzle ? 8 : 0
-  }
-  if (!inside && block.isGlow) {
-    this.height += 7 // TODO unbreak this
-  }
-  return SVG.group(children)
-}
 
-/* Document */
-
-var DocumentView = function (doc, options) {
-  Object.assign(this, doc)
-  this.scripts = doc.scripts.map(newView)
-
-  this.width = null
-  this.height = null
-  this.el = null
-  this.defs = null
-  this.scale = options.scale
-}
-
-DocumentView.prototype.measure = function () {
-  this.scripts.forEach(function (script) {
-    script.measure()
-  })
-}
-
-DocumentView.prototype.render = function (cb) {
-  if (typeof ocbptions === "function") {
-    throw new Error("render() no longer takes a callback")
-  }
-
-  // measure strings
-  this.measure()
-
-  // TODO: separate layout + render steps.
-  // render each script
-  var width = 0
-  var height = 0
-  var elements = []
-  for (var i = 0; i < this.scripts.length; i++) {
-    var script = this.scripts[i]
-    if (height) height += 10
-    script.y = height
-    elements.push(SVG.move(0, height, script.draw()))
-    height += script.height
-    if (i !== this.scripts.length - 1) height += 36
-    width = Math.max(width, script.width + 4)
-  }
-  this.width = width
-  this.height = height
-
-  // return SVG
-  var svg = SVG.newSVG(width, height, this.scale)
-  svg.appendChild((this.defs = SVG.withChildren(SVG.el("defs"), makeIcons())))
-
-  svg.appendChild(SVG.group(elements))
-  this.el = svg
-  return svg
-}
-
-/* Export SVG image as XML string */
-DocumentView.prototype.exportSVGString = function () {
-  if (this.el == null) {
-    throw new Error("call draw() first")
-  }
-
-  var style = makeStyle()
-  this.defs.appendChild(style)
-  var xml = new SVG.XMLSerializer().serializeToString(this.el)
-  this.defs.removeChild(style)
-  return xml
-}
-
-/* Export SVG image as data URI */
-DocumentView.prototype.exportSVG = function () {
-  var xml = this.exportSVGString()
-  return "data:image/svg+xml;utf8," + xml.replace(/[#]/g, encodeURIComponent)
-}
-
-DocumentView.prototype.toCanvas = function (cb, exportScale) {
-  exportScale = exportScale || 1.0
-
-  var canvas = SVG.makeCanvas()
-  canvas.width = Math.max(1, this.width * exportScale * this.scale)
-  canvas.height = Math.max(1, this.height * exportScale * this.scale)
-  var context = canvas.getContext("2d")
-
-  var image = new Image()
-  image.src = this.exportSVG()
-  image.onload = function () {
-    context.save()
-    context.scale(exportScale, exportScale)
-    context.drawImage(image, 0, 0)
-    context.restore()
-
-    cb(canvas)
+  exportPNG(cb, scale) {
+    this.toCanvas(function (canvas) {
+      if (URL && URL.createObjectURL && Blob && canvas.toBlob) {
+        var blob = canvas.toBlob(function (blob) {
+          cb(URL.createObjectURL(blob))
+        }, "image/png")
+      } else {
+        cb(canvas.toDataURL("image/png"))
+      }
+    }, scale)
   }
 }
-
-DocumentView.prototype.exportPNG = function (cb, scale) {
-  this.toCanvas(function (canvas) {
-    if (URL && URL.createObjectURL && Blob && canvas.toBlob) {
-      var blob = canvas.toBlob(function (blob) {
-        cb(URL.createObjectURL(blob))
-      }, "image/png")
-    } else {
-      cb(canvas.toDataURL("image/png"))
-    }
-  }, scale)
-}
-
-/* view */
 
 const viewFor = node => {
   switch (node.constructor) {

--- a/scratch3/blocks.js
+++ b/scratch3/blocks.js
@@ -247,7 +247,7 @@ class BlockView {
     this.isRound = this.isReporter
 
     // Avoid accidental mutation
-    this.info = Object.assign({}, block.info)
+    this.info = { ...block.info }
     if (aliasExtensions.hasOwnProperty(this.info.category)) {
       this.info.category = aliasExtensions[this.info.category]
     }

--- a/scratch3/draw.js
+++ b/scratch3/draw.js
@@ -286,8 +286,8 @@ export default SVG = {
           {
             fill: "#000",
             "fill-opacity": 0.6,
-          }
-        )
+          },
+        ),
       ),
       SVG.move(
         0,
@@ -296,7 +296,7 @@ export default SVG = {
           d: "M73.1-15.6c1.7-4.2,4.5-9.1,5.8-8.5c1.6,0.8,5.4,7.9,5,15.4c0,0.6-0.7,0.7-1.1,0.5c-3-1.6-6.4-2.8-8.6-3.6C72.8-12.3,72.4-13.7,73.1-15.6z",
           fill: "#FFD5E6",
           transform: "translate(0, 32)",
-        })
+        }),
       ),
       SVG.move(
         0,
@@ -305,7 +305,7 @@ export default SVG = {
           d: "M22.4-15.6c-1.7-4.2-4.5-9.1-5.8-8.5c-1.6,0.8-5.4,7.9-5,15.4c0,0.6,0.7,0.7,1.1,0.5c3-1.6,6.4-2.8,8.6-3.6C22.8-12.3,23.2-13.7,22.4-15.6z",
           fill: "#FFD5E6",
           transform: "translate(0, 32)",
-        })
+        }),
       ),
     ])
   },
@@ -359,7 +359,7 @@ export default SVG = {
     return SVG.move(
       -width,
       9,
-      SVG.rect(width, 2, { ...props, class: "sb3-comment-line" })
+      SVG.rect(width, 2, { ...props, class: "sb3-comment-line" }),
     )
   },
 

--- a/scratch3/draw.js
+++ b/scratch3/draw.js
@@ -1,8 +1,5 @@
 /* for constucting SVGs */
 
-function extend(src, dest) {
-  return Object.assign({}, src, dest)
-}
 function assert(bool, message) {
   if (!bool) throw "Assertion failed! " + (message || "")
 }
@@ -70,33 +67,15 @@ export default SVG = {
   },
 
   polygon(props) {
-    return SVG.el(
-      "polygon",
-      extend(props, {
-        points: props.points.join(" "),
-      })
-    )
+    return SVG.el("polygon", { ...props, points: props.points.join(" ") })
   },
 
   path(props) {
-    return SVG.el(
-      "path",
-      extend(props, {
-        path: null,
-        d: props.path.join(" "),
-      })
-    )
+    return SVG.el("path", { ...props, path: null, d: props.path.join(" ") })
   },
 
   text(x, y, content, props) {
-    var text = SVG.el(
-      "text",
-      extend(props, {
-        x: x,
-        y: y,
-        textContent: content,
-      })
-    )
+    var text = SVG.el("text", { ...props, x: x, y: y, textContent: content })
     return text
   },
 
@@ -116,38 +95,16 @@ export default SVG = {
   /* shapes */
 
   rect(w, h, props) {
-    return SVG.el(
-      "rect",
-      extend(props, {
-        x: 0,
-        y: 0,
-        width: w,
-        height: h,
-      })
-    )
+    return SVG.el("rect", { ...props, x: 0, y: 0, width: w, height: h })
   },
 
   roundRect(w, h, props) {
-    return SVG.rect(
-      w,
-      h,
-      extend(props, {
-        rx: 4,
-        ry: 4,
-      })
-    )
+    return SVG.rect(w, h, { ...props, rx: 4, ry: 4 })
   },
 
   pillRect(w, h, props) {
     var r = h / 2
-    return SVG.rect(
-      w,
-      h,
-      extend(props, {
-        rx: r,
-        ry: r,
-      })
-    )
+    return SVG.rect(w, h, { ...props, rx: r, ry: r })
   },
 
   pointedPath(w, h) {
@@ -163,11 +120,7 @@ export default SVG = {
   },
 
   pointedRect(w, h, props) {
-    return SVG.path(
-      extend(props, {
-        path: SVG.pointedPath(w, h),
-      })
-    )
+    return SVG.path({ ...props, path: SVG.pointedPath(w, h) })
   },
 
   topNotch(w, y) {
@@ -266,11 +219,10 @@ export default SVG = {
   },
 
   stackRect(w, h, props) {
-    return SVG.path(
-      extend(props, {
-        path: [SVG.getTop(w), SVG.getRightAndBottom(w, h, true, 0), "Z"],
-      })
-    )
+    return SVG.path({
+      ...props,
+      path: [SVG.getTop(w), SVG.getRightAndBottom(w, h, true, 0), "Z"],
+    })
   },
 
   capPath(w, h) {
@@ -278,11 +230,7 @@ export default SVG = {
   },
 
   capRect(w, h, props) {
-    return SVG.path(
-      extend(props, {
-        path: SVG.capPath(w, h),
-      })
-    )
+    return SVG.path({ ...props, path: SVG.capPath(w, h) })
   },
 
   getHatTop(w) {
@@ -304,20 +252,18 @@ export default SVG = {
   },
 
   hatRect(w, h, props) {
-    return SVG.path(
-      extend(props, {
-        path: [SVG.getHatTop(w), SVG.getRightAndBottom(w, h, true, 0), "Z"],
-      })
-    )
+    return SVG.path({
+      ...props,
+      path: [SVG.getHatTop(w), SVG.getRightAndBottom(w, h, true, 0), "Z"],
+    })
   },
 
   catHat(w, h, props) {
     return SVG.group([
-      SVG.path(
-        extend(props, {
-          path: [SVG.getCatTop(w), SVG.getRightAndBottom(w, h, true, 0), "Z"],
-        })
-      ),
+      SVG.path({
+        ...props,
+        path: [SVG.getCatTop(w), SVG.getRightAndBottom(w, h, true, 0), "Z"],
+      }),
       SVG.move(
         0,
         32,
@@ -374,11 +320,10 @@ export default SVG = {
   },
 
   procHatRect(w, h, props) {
-    return SVG.path(
-      extend(props, {
-        path: [SVG.getProcHatTop(w), SVG.getRightAndBottom(w, h, true, 0), "Z"],
-      })
-    )
+    return SVG.path({
+      ...props,
+      path: [SVG.getProcHatTop(w), SVG.getRightAndBottom(w, h, true, 0), "Z"],
+    })
   },
 
   mouthRect(w, h, isFinal, lines, props) {
@@ -402,44 +347,27 @@ export default SVG = {
       p.push(SVG.getRightAndBottom(w, y, hasNotch, inset))
     }
     p.push("Z")
-    return SVG.path(
-      extend(props, {
-        path: p,
-      })
-    )
+    return SVG.path({ ...props, path: p })
   },
 
   commentRect(w, h, props) {
     var r = 6
-    return SVG.roundRect(
-      w,
-      h,
-      extend(props, {
-        class: "sb3-comment",
-      })
-    )
+    return SVG.roundRect(w, h, { ...props, class: "sb3-comment" })
   },
 
   commentLine(width, props) {
     return SVG.move(
       -width,
       9,
-      SVG.rect(
-        width,
-        2,
-        extend(props, {
-          class: "sb3-comment-line",
-        })
-      )
+      SVG.rect(width, 2, { ...props, class: "sb3-comment-line" })
     )
   },
 
   strikethroughLine(w, props) {
-    return SVG.path(
-      extend(props, {
-        path: ["M", 0, 0, "L", w, 0],
-        class: "sb3-diff sb3-diff-del",
-      })
-    )
+    return SVG.path({
+      ...props,
+      path: ["M", 0, 0, "L", w, 0],
+      class: "sb3-diff sb3-diff-del",
+    })
   },
 }

--- a/scratch3/style.js
+++ b/scratch3/style.js
@@ -20,7 +20,7 @@ export default Style = {
         ]),
         {
           id: "sb3-greenFlag",
-        }
+        },
       ),
 
       SVG.setProps(
@@ -34,7 +34,7 @@ export default Style = {
         }),
         {
           id: "sb3-stopSign",
-        }
+        },
       ),
 
       SVG.setProps(
@@ -52,7 +52,7 @@ export default Style = {
         {
           id: "sb3-dropdownArrow",
           transform: "scale(0.944)",
-        }
+        },
       ),
 
       SVG.setProps(
@@ -68,7 +68,7 @@ export default Style = {
         ]),
         {
           id: "sb3-turnRight",
-        }
+        },
       ),
 
       SVG.setProps(
@@ -84,7 +84,7 @@ export default Style = {
         ]),
         {
           id: "sb3-turnLeft",
-        }
+        },
       ),
 
       SVG.el("path", {
@@ -112,7 +112,7 @@ export default Style = {
         ]),
         {
           id: "sb3-loopArrow",
-        }
+        },
       ),
 
       SVG.setProps(
@@ -148,7 +148,7 @@ export default Style = {
         ]),
         {
           id: "sb3-list",
-        }
+        },
       ),
 
       SVG.setProps(
@@ -166,7 +166,7 @@ export default Style = {
         {
           id: "sb3-musicBlock",
           fill: "none",
-        }
+        },
       ),
 
       SVG.setProps(
@@ -197,7 +197,7 @@ export default Style = {
           stroke: "#575E75",
           fill: "none",
           "stroke-linejoin": "round",
-        }
+        },
       ),
 
       SVG.setProps(
@@ -236,7 +236,7 @@ export default Style = {
           stroke: "#000",
           fill: "#FFF",
           "stroke-opacity": 0.15,
-        }
+        },
       ),
 
       SVG.setProps(
@@ -254,7 +254,7 @@ export default Style = {
           id: "sb3-ttsBlock",
           stroke: "#000",
           "stroke-opacity": 0.15,
-        }
+        },
       ),
 
       SVG.el("image", {
@@ -432,7 +432,7 @@ export default Style = {
         {
           id: "sb3-wedoBlock",
           fill: "none",
-        }
+        },
       ),
 
       SVG.setProps(
@@ -496,7 +496,7 @@ export default Style = {
         {
           transform: "translate(5.5 3.5)",
           id: "sb3-ev3Block",
-        }
+        },
       ),
 
       SVG.setProps(
@@ -550,7 +550,7 @@ export default Style = {
         {
           id: "sb3-makeymakeyBlock",
           fill: "none",
-        }
+        },
       ),
       SVG.el("image", {
         id: "sb3-gdxforBlock",

--- a/snapshots/headless.js
+++ b/snapshots/headless.js
@@ -36,7 +36,7 @@ class Renderer {
     })
 
     await this.page.goto(
-      "http://localhost:8002/snapshots/snapshot-testing.html"
+      "http://localhost:8002/snapshots/snapshot-testing.html",
     )
     await this.page.waitForFunction("window.scratchblocksLoaded")
   }

--- a/snapshots/runner.js
+++ b/snapshots/runner.js
@@ -17,7 +17,7 @@ export function runTests(r) {
       const outputPath = path.join(
         "snapshots",
         tc.style,
-        tc.name.replace(/ /g, "-") + ".png"
+        tc.name.replace(/ /g, "-") + ".png",
       )
       console.log("running", tc.name)
       return (async () => {
@@ -29,6 +29,6 @@ export function runTests(r) {
         await r.snapshotToFile(tc.source, options, outputPath)
         console.log("✓ wrote", outputPath)
       })()
-    })
+    }),
   )
 }

--- a/snapshots/tests.js
+++ b/snapshots/tests.js
@@ -37,7 +37,7 @@ set rotation style [left-right v]
 (y position)
 (direction)
 
-`
+`,
 )
 
 test(
@@ -80,7 +80,7 @@ next backdrop
 
 (backdrop #)
 
-`
+`,
 )
 
 test(
@@ -108,7 +108,7 @@ change tempo by (20)
 set tempo to (60) bpm
 (tempo)
 
-`
+`,
 )
 
 test(
@@ -135,7 +135,7 @@ set pen shade to (50)
 change pen size by (1)
 set pen size to (1)
 
-`
+`,
 )
 
 test(
@@ -165,7 +165,7 @@ replace item (1 v) of [list v] with [thing]
 show list [list v]
 hide list [list v]
 
-`
+`,
 )
 
 test(
@@ -189,7 +189,7 @@ when I receive [message1 v]
 broadcast [message1 v]
 broadcast [message1 v] and wait
 
-`
+`,
 )
 
 test(
@@ -235,7 +235,7 @@ when I start as a clone
 create clone of [myself v]
 delete this clone
 
-`
+`,
 )
 
 test(
@@ -275,7 +275,7 @@ reset timer
 (user id)
 
 
-`
+`,
 )
 
 test(
@@ -311,7 +311,7 @@ test(
 
 ([sqrt v] of (9))
 
-`
+`,
 )
 /* Scratch 2.0 extension support is not good
 test(
@@ -424,7 +424,7 @@ when Sprite1 clicked
 ...
 …
 
-`
+`,
 )
 
 /*****************************************************************************/
@@ -462,7 +462,7 @@ set rotation style [left-right v]
 (y position)
 (direction)
 
-`
+`,
 )
 
 test(
@@ -499,7 +499,7 @@ go [forward v] (1) layers
 (backdrop [number v])
 (size)
 
-`
+`,
 )
 
 test(
@@ -522,7 +522,7 @@ set volume to (100) %
 
 volume
 
-`
+`,
 )
 
 test(
@@ -543,7 +543,7 @@ when i receive [message1 v]
 broadcast (message1 v)
 broadcast (message1 v) and wait
 
-`
+`,
 )
 
 test(
@@ -579,7 +579,7 @@ when I start as a clone
 create clone of (myself v)
 delete this clone 
 
-`
+`,
 )
 
 test(
@@ -618,7 +618,7 @@ reset timer
 (days since 2000)
 (username)
 
-`
+`,
 )
 
 test(
@@ -653,7 +653,7 @@ test(
 
 ([abs v] of ())
 
-`
+`,
 )
 
 test(
@@ -688,7 +688,7 @@ replace item (1) of [list v] with (1)
 show list [list v]
 hide list [list v]
 
-`
+`,
 )
 
 test(
@@ -702,7 +702,7 @@ foo () if <>
 
 define foo (num) if <bool>
 
-`
+`,
 )
 
 test(
@@ -727,7 +727,7 @@ set pen (color v) to (50)
 change pen size by (1)
 set pen size to (1)
 
-`
+`,
 )
 
 test(
@@ -745,7 +745,7 @@ set tempo to (60)
 change tempo by (20)
 (tempo)
 
-`
+`,
 )
 
 test(
@@ -760,7 +760,7 @@ when video motion > (10)
 turn video (on v)
 set video transparency to (50)
 
-`
+`,
 )
 
 test(
@@ -829,7 +829,7 @@ when force sensor [pushed v]
 <falling?>
 (spin speed [z v])
 (acceleration [x v])
-`
+`,
 )
 
 test(
@@ -840,7 +840,7 @@ move (10) steps
 
 when flag clicked :: cat
 move (10) steps
-`
+`,
 )
 
 /*****************************************************************************/
@@ -881,7 +881,7 @@ setze Drehtyp auf [links-rechts v]
 (Richtung)
 
 `,
-  "de"
+  "de",
 )
 
 test(
@@ -921,7 +921,7 @@ gehe (1) Ebenen [nach vorne v]
 (Größe)
 
 `,
-  "de"
+  "de",
 )
 // "gehe Ebenen nach vorne" appears differently in the Scratch editor than in
 // the translation files, wut
@@ -948,7 +948,7 @@ setze Lautstärke auf (100) %
 
 
 `,
-  "de"
+  "de",
 )
 
 test(
@@ -970,7 +970,7 @@ sende (Nachricht1 v) an alle
 sende (Nachricht1 v) an alle und warte
 
 `,
-  "de"
+  "de",
 )
 
 test(
@@ -1007,7 +1007,7 @@ erzeuge Klon von (mir selbst v)
 lösche diesen Klon
 
 `,
-  "de"
+  "de",
 )
 
 test(
@@ -1044,7 +1044,7 @@ setze Stoppuhr zurück
 (Benutzername)
 
 `,
-  "de"
+  "de",
 )
 
 test(
@@ -1081,7 +1081,7 @@ test(
 ([Betrag v] von (foo))
 
 `,
-  "de"
+  "de",
 )
 
 test(
@@ -1117,7 +1117,7 @@ zeige Liste [list v]
 verstecke Liste [list v]
 
 `,
-  "de"
+  "de",
 )
 
 test(
@@ -1132,7 +1132,7 @@ foo () if <>
 Definiere foo (num) if <bool>
 
 `,
-  "de"
+  "de",
 )
 
 test(
@@ -1158,7 +1158,7 @@ setze Stift (Farbe v) auf (50)
 setze Stiftdicke auf (1)
 
 `,
-  "de"
+  "de",
 )
 
 test(
@@ -1178,7 +1178,7 @@ setze tempo auf (60)
 (Tempo)
 
 `,
-  "de"
+  "de",
 )
 
 test(
@@ -1196,7 +1196,7 @@ schalte Video (an v)
 setze Video-Transparenz auf (50)
 
 `,
-  "de"
+  "de",
 )
 
 test(
@@ -1268,5 +1268,5 @@ Wenn Kraftsensor [gedrückt v]
 (Rotationsgeschwindigkeit [z v])
 (Beschleunigung [x v])
 `,
-  "de"
+  "de",
 )

--- a/syntax/blocks.js
+++ b/syntax/blocks.js
@@ -49,7 +49,7 @@ var inputPatGlobal = new RegExp(inputPat.source, "g")
 export var iconPat = /(@[a-zA-Z]+)/
 var splitPat = new RegExp(
   [inputPat.source, "|", iconPat.source, "| +"].join(""),
-  "g"
+  "g",
 )
 
 export var hexColorPat = /^#(?:[0-9a-fA-F]{3}){1,2}?$/
@@ -298,7 +298,7 @@ disambig(
       }
     }
     return false
-  }
+  },
 )
 
 disambig("SOUND_SETEFFECTO", "LOOKS_SETEFFECTTO", function (children, lang) {
@@ -332,7 +332,7 @@ disambig(
     var first = children[0]
     if (!first.isInput) return
     return first.shape === "dropdown"
-  }
+  },
 )
 
 disambig("pen.setColor", "pen.setHue", function (children, lang) {
@@ -360,7 +360,7 @@ disambig(
       }
     }
     return false
-  }
+  },
 )
 
 // This block does not need disambiguation in English;
@@ -384,7 +384,7 @@ disambig(
       }
     }
     return false
-  }
+  },
 )
 
 specialCase("CONTROL_STOP", function (info, children, lang) {

--- a/syntax/blocks.js
+++ b/syntax/blocks.js
@@ -393,9 +393,7 @@ specialCase("CONTROL_STOP", function (info, children, lang) {
   if (!last.isInput) return
   var value = last.value
   if (lang.osis.indexOf(value) > -1) {
-    return Object.assign({}, blocksById["CONTROL_STOP"], {
-      shape: "stack",
-    })
+    return { ...blocksById["CONTROL_STOP"], shape: "stack" }
   }
 })
 

--- a/syntax/model.js
+++ b/syntax/model.js
@@ -139,7 +139,7 @@ export class Input {
 export class Block {
   constructor(info, children, comment) {
     assert(info)
-    this.info = Object.assign({}, info)
+    this.info = { ...info }
     this.children = children
     this.comment = comment || null
     this.diff = null

--- a/syntax/syntax.js
+++ b/syntax/syntax.js
@@ -92,7 +92,7 @@ function paintBlock(info, children, languages) {
       // () and [] shapes as we go.
       const outlineChildren = children.splice(
         lang.definePrefix.length,
-        children.length - lang.defineSuffix.length
+        children.length - lang.defineSuffix.length,
       )
 
       for (let i = 0; i < outlineChildren.length; i++) {
@@ -106,7 +106,7 @@ function paintBlock(info, children, languages) {
               category: "custom-arg",
             },
             [new Label("")],
-            languages
+            languages,
           )
         } else if (
           child.isInput &&
@@ -121,7 +121,7 @@ function paintBlock(info, children, languages) {
               category: "custom-arg",
             },
             labels,
-            languages
+            languages,
           )
         } else if (child.isReporter || child.isBoolean) {
           // Convert variables to number arguments, predicates to boolean arguments.
@@ -298,7 +298,7 @@ function parseLines(code, languages) {
             children.push(
               Icon.icons.hasOwnProperty(name)
                 ? new Icon(name)
-                : new Label("@" + name)
+                : new Label("@" + name),
             )
           }
           label = null
@@ -728,7 +728,7 @@ function recogniseStuff(scripts) {
                 number: "%n",
                 string: "%s",
                 boolean: "%b",
-              }[child.info.argument]
+              }[child.info.argument],
             )
 
             var name = blockName(child)

--- a/syntax/syntax.js
+++ b/syntax/syntax.js
@@ -566,12 +566,7 @@ function parseScripts(getLine) {
         }
 
         if (b.isElse || b.isEnd) {
-          b = new Block(
-            Object.assign({}, b.info, {
-              shape: "stack",
-            }),
-            b.children
-          )
+          b = new Block({ ...b.info, shape: "stack" }, b.children)
         }
 
         if (isGlow) {
@@ -833,13 +828,11 @@ function recogniseStuff(scripts) {
 }
 
 export function parse(code, options) {
-  var options = Object.assign(
-    {
-      inline: false,
-      languages: ["en"],
-    },
-    options
-  )
+  var options = {
+    inline: false,
+    languages: ["en"],
+    ...options,
+  }
 
   if (options.dialect) {
     throw new Error("Option 'dialect' no longer supported")


### PR DESCRIPTION
This PR finishes migrating things from boring ol' `Object.prototype` to shiny new `class` syntax.  For #413.