### PR TITLE
prettier: Prefer trailing comma

### DIFF
--- a/locales-src/build-locales.js
+++ b/locales-src/build-locales.js
@@ -25,10 +25,10 @@ const rawLocales = async () => {
     const raw = {
       code: code,
       mappings: await readJSONFile(
-        `node_modules/scratch-l10n/editor/blocks/${code}.json`
+        `node_modules/scratch-l10n/editor/blocks/${code}.json`,
       ),
       extensionMappings: await readJSONFile(
-        `node_modules/scratch-l10n/editor/extensions/${code}.json`
+        `node_modules/scratch-l10n/editor/extensions/${code}.json`,
       ),
     }
     if (code === "en") {
@@ -191,7 +191,7 @@ const buildLocale = (code, rawLocale) => {
   }
   const frac = commandCount / scratchSpecs.length
   console.log(
-    `${(code + ":").padEnd(8)} ${(frac * 100).toFixed(1).padStart(5)}%`
+    `${(code + ":").padEnd(8)} ${(frac * 100).toFixed(1).padStart(5)}%`,
   )
 
   // Approximate fraction of blocks translated. For some reason not all blocks

--- a/locales-src/rollup-optimized-css-text.js
+++ b/locales-src/rollup-optimized-css-text.js
@@ -15,7 +15,7 @@ export default opts => {
         return Promise.resolve(
           opts.minify
             ? import("csso").then(csso => csso.minify(code).css)
-            : code
+            : code,
         ).then(processed => ({
           code: "export default " + JSON.stringify(processed),
           map: { mappings: "" },

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   "pre-commit": "lint:staged",
   "prettier": {
     "semi": false,
-    "trailingComma": "es5",
+    "trailingComma": "all",
     "arrowParens": "avoid"
   },
   "jest": {

--- a/scratch2/blocks.js
+++ b/scratch2/blocks.js
@@ -143,7 +143,7 @@ class InputView {
       var w = Math.max(
         14,
         this.label.width +
-          (this.shape === "string" || this.shape === "number-dropdown" ? 6 : 9)
+          (this.shape === "string" || this.shape === "number-dropdown" ? 6 : 9),
       )
     } else {
       var w = this.isInset ? 30 : this.isColor ? 13 : null
@@ -186,8 +186,8 @@ class InputView {
             points: [7, 0, 3.5, 4, 0, 0],
             fill: "#000",
             opacity: "0.6",
-          })
-        )
+          }),
+        ),
       )
     }
     return result
@@ -411,7 +411,7 @@ class BlockView {
         ? 83
         : this.isCommand || this.isOutline || this.isRing
         ? 39
-        : 20
+        : 20,
     )
     this.height = y
     this.width = scriptWidth
@@ -663,8 +663,8 @@ class DocumentView {
           bevelFilter("bevelFilter", false),
           bevelFilter("inputBevelFilter", true),
           darkFilter("inputDarkFilter"),
-        ].concat(makeIcons())
-      ))
+        ].concat(makeIcons()),
+      )),
     )
 
     svg.appendChild(SVG.group(elements))

--- a/scratch2/draw.js
+++ b/scratch2/draw.js
@@ -403,7 +403,7 @@ export default SVG = {
       SVG.group([
         SVG.procHatBase(w, q, archRoundness, props),
         SVG.procHatCap(w, q, archRoundness),
-      ])
+      ]),
     )
   },
 
@@ -471,7 +471,7 @@ export default SVG = {
     return SVG.move(
       -width,
       9,
-      SVG.rect(width, 2, { ...props, class: "sb-comment-line" })
+      SVG.rect(width, 2, { ...props, class: "sb-comment-line" }),
     )
   },
 

--- a/scratch2/filter.js
+++ b/scratch2/filter.js
@@ -19,8 +19,8 @@ export default class Filter {
     this.el.appendChild(
       SVG.withChildren(
         SVG.el("fe" + name, { ...props, result: id }),
-        children || []
-      )
+        children || [],
+      ),
     )
     return id
   }
@@ -72,7 +72,7 @@ export default class Filter {
         return SVG.el("feMergeNode", {
           in: name,
         })
-      })
+      }),
     )
   }
 }

--- a/scratch2/style.js
+++ b/scratch2/style.js
@@ -53,12 +53,12 @@ export default Style = {
               d: "M8 0l2 -2l0 -3l3 0l-4 -5l-4 5l3 0l0 3l-8 0l0 2",
               fill: "#fff",
               opacity: "0.9",
-            })
+            }),
           ),
         ]),
         {
           id: "loopArrow",
-        }
+        },
       ),
       SVG.setProps(
         SVG.group([
@@ -150,7 +150,7 @@ export default Style = {
         ]),
         {
           id: "list",
-        }
+        },
       ),
     ]
   },
@@ -173,12 +173,12 @@ export default Style = {
       f.comp(
         "in",
         f.flood("#fff", 0.15),
-        f.subtract(alpha, f.offset(+s, +s, blur))
+        f.subtract(alpha, f.offset(+s, +s, blur)),
       ),
       f.comp(
         "in",
         f.flood("#000", 0.7),
-        f.subtract(alpha, f.offset(-s, -s, blur))
+        f.subtract(alpha, f.offset(-s, -s, blur)),
       ),
     ])
 
@@ -203,7 +203,7 @@ export default Style = {
           class: ["sb-" + category, "sb-darker"].join(" "),
         }),
       ]),
-      { width: w, height: h }
+      { width: w, height: h },
     )
   },
 

--- a/scratch3/blocks.js
+++ b/scratch3/blocks.js
@@ -232,7 +232,7 @@ export class InputView {
     }
     if (this.hasArrow) {
       result.appendChild(
-        SVG.move(w - 24, 13, SVG.symbol("#sb3-dropdownArrow", {}))
+        SVG.move(w - 24, 13, SVG.symbol("#sb3-dropdownArrow", {})),
       )
     }
     return result
@@ -254,7 +254,7 @@ class BlockView {
     if (extensions.hasOwnProperty(this.info.category)) {
       this.children.unshift(new LineView())
       this.children.unshift(
-        new IconView({ name: this.info.category + "Block" })
+        new IconView({ name: this.info.category + "Block" }),
       )
       this.info.category = "extension"
     }
@@ -511,7 +511,7 @@ class BlockView {
         : this.isReporter
         ? 48
         : 0,
-      innerWidth
+      innerWidth,
     )
 
     // Center the label text inside small reporters.

--- a/scratch3/draw.js
+++ b/scratch3/draw.js
@@ -286,8 +286,8 @@ export default SVG = {
           {
             fill: "#000",
             "fill-opacity": 0.6,
-          }
-        )
+          },
+        ),
       ),
       SVG.move(
         0,
@@ -296,7 +296,7 @@ export default SVG = {
           d: "M73.1-15.6c1.7-4.2,4.5-9.1,5.8-8.5c1.6,0.8,5.4,7.9,5,15.4c0,0.6-0.7,0.7-1.1,0.5c-3-1.6-6.4-2.8-8.6-3.6C72.8-12.3,72.4-13.7,73.1-15.6z",
           fill: "#FFD5E6",
           transform: "translate(0, 32)",
-        })
+        }),
       ),
       SVG.move(
         0,
@@ -305,7 +305,7 @@ export default SVG = {
           d: "M22.4-15.6c-1.7-4.2-4.5-9.1-5.8-8.5c-1.6,0.8-5.4,7.9-5,15.4c0,0.6,0.7,0.7,1.1,0.5c3-1.6,6.4-2.8,8.6-3.6C22.8-12.3,23.2-13.7,22.4-15.6z",
           fill: "#FFD5E6",
           transform: "translate(0, 32)",
-        })
+        }),
       ),
     ])
   },
@@ -359,7 +359,7 @@ export default SVG = {
     return SVG.move(
       -width,
       9,
-      SVG.rect(width, 2, { ...props, class: "sb3-comment-line" })
+      SVG.rect(width, 2, { ...props, class: "sb3-comment-line" }),
     )
   },
 

--- a/scratch3/style.js
+++ b/scratch3/style.js
@@ -20,7 +20,7 @@ export default Style = {
         ]),
         {
           id: "sb3-greenFlag",
-        }
+        },
       ),
 
       SVG.setProps(
@@ -34,7 +34,7 @@ export default Style = {
         }),
         {
           id: "sb3-stopSign",
-        }
+        },
       ),
 
       SVG.setProps(
@@ -52,7 +52,7 @@ export default Style = {
         {
           id: "sb3-dropdownArrow",
           transform: "scale(0.944)",
-        }
+        },
       ),
 
       SVG.setProps(
@@ -68,7 +68,7 @@ export default Style = {
         ]),
         {
           id: "sb3-turnRight",
-        }
+        },
       ),
 
       SVG.setProps(
@@ -84,7 +84,7 @@ export default Style = {
         ]),
         {
           id: "sb3-turnLeft",
-        }
+        },
       ),
 
       SVG.el("path", {
@@ -112,7 +112,7 @@ export default Style = {
         ]),
         {
           id: "sb3-loopArrow",
-        }
+        },
       ),
 
       SVG.setProps(
@@ -148,7 +148,7 @@ export default Style = {
         ]),
         {
           id: "sb3-list",
-        }
+        },
       ),
 
       SVG.setProps(
@@ -166,7 +166,7 @@ export default Style = {
         {
           id: "sb3-musicBlock",
           fill: "none",
-        }
+        },
       ),
 
       SVG.setProps(
@@ -197,7 +197,7 @@ export default Style = {
           stroke: "#575E75",
           fill: "none",
           "stroke-linejoin": "round",
-        }
+        },
       ),
 
       SVG.setProps(
@@ -236,7 +236,7 @@ export default Style = {
           stroke: "#000",
           fill: "#FFF",
           "stroke-opacity": 0.15,
-        }
+        },
       ),
 
       SVG.setProps(
@@ -254,7 +254,7 @@ export default Style = {
           id: "sb3-ttsBlock",
           stroke: "#000",
           "stroke-opacity": 0.15,
-        }
+        },
       ),
 
       SVG.el("image", {
@@ -432,7 +432,7 @@ export default Style = {
         {
           id: "sb3-wedoBlock",
           fill: "none",
-        }
+        },
       ),
 
       SVG.setProps(
@@ -496,7 +496,7 @@ export default Style = {
         {
           transform: "translate(5.5 3.5)",
           id: "sb3-ev3Block",
-        }
+        },
       ),
 
       SVG.setProps(
@@ -550,7 +550,7 @@ export default Style = {
         {
           id: "sb3-makeymakeyBlock",
           fill: "none",
-        }
+        },
       ),
       SVG.el("image", {
         id: "sb3-gdxforBlock",

--- a/snapshots/headless.js
+++ b/snapshots/headless.js
@@ -36,7 +36,7 @@ class Renderer {
     })
 
     await this.page.goto(
-      "http://localhost:8002/snapshots/snapshot-testing.html"
+      "http://localhost:8002/snapshots/snapshot-testing.html",
     )
     await this.page.waitForFunction("window.scratchblocksLoaded")
   }

--- a/snapshots/runner.js
+++ b/snapshots/runner.js
@@ -17,7 +17,7 @@ export function runTests(r) {
       const outputPath = path.join(
         "snapshots",
         tc.style,
-        tc.name.replace(/ /g, "-") + ".png"
+        tc.name.replace(/ /g, "-") + ".png",
       )
       console.log("running", tc.name)
       return (async () => {
@@ -29,6 +29,6 @@ export function runTests(r) {
         await r.snapshotToFile(tc.source, options, outputPath)
         console.log("✓ wrote", outputPath)
       })()
-    })
+    }),
   )
 }

--- a/snapshots/tests.js
+++ b/snapshots/tests.js
@@ -37,7 +37,7 @@ set rotation style [left-right v]
 (y position)
 (direction)
 
-`
+`,
 )
 
 test(
@@ -80,7 +80,7 @@ next backdrop
 
 (backdrop #)
 
-`
+`,
 )
 
 test(
@@ -108,7 +108,7 @@ change tempo by (20)
 set tempo to (60) bpm
 (tempo)
 
-`
+`,
 )
 
 test(
@@ -135,7 +135,7 @@ set pen shade to (50)
 change pen size by (1)
 set pen size to (1)
 
-`
+`,
 )
 
 test(
@@ -165,7 +165,7 @@ replace item (1 v) of [list v] with [thing]
 show list [list v]
 hide list [list v]
 
-`
+`,
 )
 
 test(
@@ -189,7 +189,7 @@ when I receive [message1 v]
 broadcast [message1 v]
 broadcast [message1 v] and wait
 
-`
+`,
 )
 
 test(
@@ -235,7 +235,7 @@ when I start as a clone
 create clone of [myself v]
 delete this clone
 
-`
+`,
 )
 
 test(
@@ -275,7 +275,7 @@ reset timer
 (user id)
 
 
-`
+`,
 )
 
 test(
@@ -311,7 +311,7 @@ test(
 
 ([sqrt v] of (9))
 
-`
+`,
 )
 /* Scratch 2.0 extension support is not good
 test(
@@ -424,7 +424,7 @@ when Sprite1 clicked
 ...
 …
 
-`
+`,
 )
 
 /*****************************************************************************/
@@ -462,7 +462,7 @@ set rotation style [left-right v]
 (y position)
 (direction)
 
-`
+`,
 )
 
 test(
@@ -499,7 +499,7 @@ go [forward v] (1) layers
 (backdrop [number v])
 (size)
 
-`
+`,
 )
 
 test(
@@ -522,7 +522,7 @@ set volume to (100) %
 
 volume
 
-`
+`,
 )
 
 test(
@@ -543,7 +543,7 @@ when i receive [message1 v]
 broadcast (message1 v)
 broadcast (message1 v) and wait
 
-`
+`,
 )
 
 test(
@@ -579,7 +579,7 @@ when I start as a clone
 create clone of (myself v)
 delete this clone 
 
-`
+`,
 )
 
 test(
@@ -618,7 +618,7 @@ reset timer
 (days since 2000)
 (username)
 
-`
+`,
 )
 
 test(
@@ -653,7 +653,7 @@ test(
 
 ([abs v] of ())
 
-`
+`,
 )
 
 test(
@@ -688,7 +688,7 @@ replace item (1) of [list v] with (1)
 show list [list v]
 hide list [list v]
 
-`
+`,
 )
 
 test(
@@ -702,7 +702,7 @@ foo () if <>
 
 define foo (num) if <bool>
 
-`
+`,
 )
 
 test(
@@ -727,7 +727,7 @@ set pen (color v) to (50)
 change pen size by (1)
 set pen size to (1)
 
-`
+`,
 )
 
 test(
@@ -745,7 +745,7 @@ set tempo to (60)
 change tempo by (20)
 (tempo)
 
-`
+`,
 )
 
 test(
@@ -760,7 +760,7 @@ when video motion > (10)
 turn video (on v)
 set video transparency to (50)
 
-`
+`,
 )
 
 test(
@@ -829,7 +829,7 @@ when force sensor [pushed v]
 <falling?>
 (spin speed [z v])
 (acceleration [x v])
-`
+`,
 )
 
 test(
@@ -840,7 +840,7 @@ move (10) steps
 
 when flag clicked :: cat
 move (10) steps
-`
+`,
 )
 
 /*****************************************************************************/
@@ -881,7 +881,7 @@ setze Drehtyp auf [links-rechts v]
 (Richtung)
 
 `,
-  "de"
+  "de",
 )
 
 test(
@@ -921,7 +921,7 @@ gehe (1) Ebenen [nach vorne v]
 (Größe)
 
 `,
-  "de"
+  "de",
 )
 // "gehe Ebenen nach vorne" appears differently in the Scratch editor than in
 // the translation files, wut
@@ -948,7 +948,7 @@ setze Lautstärke auf (100) %
 
 
 `,
-  "de"
+  "de",
 )
 
 test(
@@ -970,7 +970,7 @@ sende (Nachricht1 v) an alle
 sende (Nachricht1 v) an alle und warte
 
 `,
-  "de"
+  "de",
 )
 
 test(
@@ -1007,7 +1007,7 @@ erzeuge Klon von (mir selbst v)
 lösche diesen Klon
 
 `,
-  "de"
+  "de",
 )
 
 test(
@@ -1044,7 +1044,7 @@ setze Stoppuhr zurück
 (Benutzername)
 
 `,
-  "de"
+  "de",
 )
 
 test(
@@ -1081,7 +1081,7 @@ test(
 ([Betrag v] von (foo))
 
 `,
-  "de"
+  "de",
 )
 
 test(
@@ -1117,7 +1117,7 @@ zeige Liste [list v]
 verstecke Liste [list v]
 
 `,
-  "de"
+  "de",
 )
 
 test(
@@ -1132,7 +1132,7 @@ foo () if <>
 Definiere foo (num) if <bool>
 
 `,
-  "de"
+  "de",
 )
 
 test(
@@ -1158,7 +1158,7 @@ setze Stift (Farbe v) auf (50)
 setze Stiftdicke auf (1)
 
 `,
-  "de"
+  "de",
 )
 
 test(
@@ -1178,7 +1178,7 @@ setze tempo auf (60)
 (Tempo)
 
 `,
-  "de"
+  "de",
 )
 
 test(
@@ -1196,7 +1196,7 @@ schalte Video (an v)
 setze Video-Transparenz auf (50)
 
 `,
-  "de"
+  "de",
 )
 
 test(
@@ -1268,5 +1268,5 @@ Wenn Kraftsensor [gedrückt v]
 (Rotationsgeschwindigkeit [z v])
 (Beschleunigung [x v])
 `,
-  "de"
+  "de",
 )

--- a/syntax/blocks.js
+++ b/syntax/blocks.js
@@ -49,7 +49,7 @@ var inputPatGlobal = new RegExp(inputPat.source, "g")
 export var iconPat = /(@[a-zA-Z]+)/
 var splitPat = new RegExp(
   [inputPat.source, "|", iconPat.source, "| +"].join(""),
-  "g"
+  "g",
 )
 
 export var hexColorPat = /^#(?:[0-9a-fA-F]{3}){1,2}?$/
@@ -298,7 +298,7 @@ disambig(
       }
     }
     return false
-  }
+  },
 )
 
 disambig("SOUND_SETEFFECTO", "LOOKS_SETEFFECTTO", function (children, lang) {
@@ -332,7 +332,7 @@ disambig(
     var first = children[0]
     if (!first.isInput) return
     return first.shape === "dropdown"
-  }
+  },
 )
 
 disambig("pen.setColor", "pen.setHue", function (children, lang) {
@@ -360,7 +360,7 @@ disambig(
       }
     }
     return false
-  }
+  },
 )
 
 // This block does not need disambiguation in English;
@@ -384,7 +384,7 @@ disambig(
       }
     }
     return false
-  }
+  },
 )
 
 specialCase("CONTROL_STOP", function (info, children, lang) {

--- a/syntax/syntax.js
+++ b/syntax/syntax.js
@@ -92,7 +92,7 @@ function paintBlock(info, children, languages) {
       // () and [] shapes as we go.
       const outlineChildren = children.splice(
         lang.definePrefix.length,
-        children.length - lang.defineSuffix.length
+        children.length - lang.defineSuffix.length,
       )
 
       for (let i = 0; i < outlineChildren.length; i++) {
@@ -106,7 +106,7 @@ function paintBlock(info, children, languages) {
               category: "custom-arg",
             },
             [new Label("")],
-            languages
+            languages,
           )
         } else if (
           child.isInput &&
@@ -121,7 +121,7 @@ function paintBlock(info, children, languages) {
               category: "custom-arg",
             },
             labels,
-            languages
+            languages,
           )
         } else if (child.isReporter || child.isBoolean) {
           // Convert variables to number arguments, predicates to boolean arguments.
@@ -298,7 +298,7 @@ function parseLines(code, languages) {
             children.push(
               Icon.icons.hasOwnProperty(name)
                 ? new Icon(name)
-                : new Label("@" + name)
+                : new Label("@" + name),
             )
           }
           label = null
@@ -728,7 +728,7 @@ function recogniseStuff(scripts) {
                 number: "%n",
                 string: "%s",
                 boolean: "%b",
-              }[child.info.argument]
+              }[child.info.argument],
             )
 
             var name = blockName(child)


### PR DESCRIPTION
Now that we're porting the codebase to ES6 (#413), we can safely prefer trailing commas. This PR updates the `package.json` and then re-runs `npm run fmt`!