### PR TITLE
Allow for using define hat shape as a modifier

### DIFF
--- a/scratch2/blocks.js
+++ b/scratch2/blocks.js
@@ -352,6 +352,8 @@ class BlockView {
     const isDefine = this.info.shape === "define-hat"
     let children = this.children
 
+    const hasOutlineChild = children.find(child => child.isOutline)
+
     const padding = BlockView.padding[this.info.shape] || BlockView.padding.null
     let pt = padding[0]
     const px = padding[1]
@@ -451,7 +453,8 @@ class BlockView {
       ? Math.max(innerWidth, 15 + scriptWidth)
       : innerWidth
     if (isDefine) {
-      const p = Math.min(26, (3.5 + 0.13 * innerWidth) | 0) - 18
+      let p = Math.min(26, (3.5 + 0.13 * innerWidth) | 0) - 18
+      if (!hasOutlineChild) p += 6
       this.height += p
       pt += 2 * p
     }
@@ -501,6 +504,17 @@ class BlockView {
       SVG.setProps(el, {
         fill: this.info.color,
       })
+    }
+
+    if (isDefine && !hasOutlineChild) {
+      const cap = el.querySelector(".sb-define-hat-cap")
+      if (cap) {
+        SVG.setProps(cap, {
+          stroke: this.info.color,
+          fill: "rgba(255, 255, 255, 0.15)",
+          class: `sb-${this.info.category}`,
+        })
+      }
     }
 
     return SVG.group(objects)

--- a/syntax/blocks.js
+++ b/syntax/blocks.js
@@ -29,6 +29,7 @@ const overrideShapes = [
   "reporter",
   "ring",
   "cat",
+  "define-hat",
 ]
 
 // languages that should be displayed right to left


### PR DESCRIPTION
Mentioned in #449

This pull request adds `define-hat` to the list of override shapes, and modifies `draw()` to render the blocks without clipping on the top (happens otherwise if you don't have a block inside the define hat) and to show the 2.0 define hat cap with different colors from the custom purple.

Currently, this lacks the ability to make outline blocks like in the normal define block.
It also needs a rework to how the fill color on the cap for 2.0 works. It is currently the same color as the stroke for a category modifier, which might require manually choosing new colors for each category except custom. For rgb color input, it uses a brighter shade of the color for the fill. This doesn't look quite the same as the normal define block by comparison, although there isn't much else you can do for a custom color.