### PR TITLE
Left-align short list reporter labels

### DIFF
--- a/scratch3/blocks.js
+++ b/scratch3/blocks.js
@@ -553,8 +553,10 @@ class BlockView {
       innerWidth,
     )
 
-    // Center the label text inside small reporters.
-    if (this.isReporter) {
+    // Center the label text inside reporters with short names.
+    //
+    // Scratch doesn't do this for lists for some reason??
+    if (this.isReporter && this.info.category !== "list") {
       padLeft += (innerWidth - originalInnerWidth) / 2
     }
 


### PR DESCRIPTION
Scratchblocks has always centered the labels inside reporters with short names. It turns out Scratch (by mistake?) left-aligns some reporters, including list reporters.

Closes #506.

```
(v)

(l :: list)
```

![scratchblocks(3)](https://github.com/scratchblocks/scratchblocks/assets/639289/f73a109a-39e0-4a85-b0f2-485298e4f80e)

Thanks to @husqwc for reporting!