### PR TITLE
Fix minimum hat width

### DIFF
--- a/scratch3/blocks.js
+++ b/scratch3/blocks.js
@@ -536,15 +536,14 @@ class BlockView {
     const padRight = children.length ? this.horizontalPadding(lastChild) : 0
     innerWidth += padLeft + padRight
 
-    // Commands have a minimum width
-    // The hat min-width is arbitrary (not sure of Scratch 3 value)
-    // Outline min-width is deliberately higher (because Scratch 3 looks silly)
+    // Commands have a minimum width.
+    // Outline min-width is deliberately higher (because Scratch 3 looks silly).
     const originalInnerWidth = innerWidth
     innerWidth = Math.max(
       this.hasScript
         ? 160
         : this.isHat
-        ? 108
+        ? 100 // Correct for Scratch 3.0.
         : this.isCommand || this.isOutline
         ? 64
         : this.isReporter


### PR DESCRIPTION
The hat min-width for Scratch 3.0 was arbitrary (i.e. made up). This change fixes it to the correct value as used by Scratch.

Checked against the block `當分身產生` in the language `zh_tw`.

Closes #508.

Thanks to @husqwc for reporting, and @CST1229 for investigating!