### PR TITLE
Fix incorrect translation keys [WIP]

### DIFF
--- a/locales-src/build-locales.js
+++ b/locales-src/build-locales.js
@@ -86,7 +86,7 @@ const translateKey = (raw, key) => {
     throw new Error(`Unknown key: '${key}'`)
   }
   if (!result) {
-    return
+    return null
   }
   //if (result === englishResult) return
   return fixup(key, result, englishResult)
@@ -149,6 +149,7 @@ const buildLocale = (code, rawLocale) => {
     name: localeNames[code].name,
   }
 
+  let translatableCount = 0
   for (const command of scratchCommands) {
     if (!command.id) {
       continue
@@ -159,9 +160,16 @@ const buildLocale = (code, rawLocale) => {
     if (/^scratchblocks:/.test(command.id)) {
       continue
     }
+    translatableCount += 1
+
     const result = translateKey(rawLocale, command.id)
-    if (!result) {
+    if (result == null) {
+      // The language is missing the key.
+      console.log("Language", code, "is missing key", command.id)
       continue
+    }
+    if (locale.commands[command.id] != null) {
+      console.log("duplicate translation", command.id)
     }
     locale.commands[command.id] = result
   }
@@ -171,7 +179,7 @@ const buildLocale = (code, rawLocale) => {
     console.log("No blocks:", localeNames[code].name)
     return
   }
-  const frac = commandCount / scratchSpecs.length
+  const frac = commandCount / translatableCount
   console.log(
     `${(code + ":").padEnd(8)} ${(frac * 100).toFixed(1).padStart(5)}%`,
   )
@@ -179,7 +187,7 @@ const buildLocale = (code, rawLocale) => {
   // Approximate fraction of blocks translated. For some reason not all blocks
   // are included; most locales are 93.7% translated according to this script.
   // So we cheat and treat that as 100.
-  locale.percentTranslated = Math.max(100, Math.round((frac / 0.937) * 100))
+  //locale.percentTranslated = Math.max(100, Math.round((frac / 0.937) * 100))
 
   // TODO does this block still exist?
   //const whenDistance = translateKey("when distance < %1")

--- a/locales/ab.json
+++ b/locales/ab.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "аҽыҵәахра",
     "LOOKS_SWITCHCOSTUMETO": "иԥсахтәуп акостиум %1 ала",
     "LOOKS_NEXTCOSTUME": "анаҩстәи акостиум",
-    "LOOKS_NEXTBACKDROP_BLOCK": "анаҩстәи аҿаԥшыра",
+    "LOOKS_NEXTBACKDROP": "анаҩстәи аҿаԥшыра",
     "LOOKS_SWITCHBACKDROPTO": "иԥсахтәуп аҿаԥшыра %1 ала",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "иԥсахтәуп аҿаԥшыра %1 ала  нас иԥштәуп",
     "LOOKS_CHANGEEFFECTBY": "иԥсахтәуп аеффект %1  %2 ала",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "%2 аҟны иԥсахтәуп аелемент %1 %3 ала",
     "DATA_SHOWLIST": "иаарԥштәуп асиа %1",
     "DATA_HIDELIST": "иҵәахтәуп асиа %1",
-    "SENSING_OF_XPOSITION": "x аҭыԥ",
-    "SENSING_OF_YPOSITION": "y аҭыԥ",
-    "SENSING_OF_DIRECTION": "ахырхарҭа",
+    "MOTION_XPOSITION": "x апозициа",
+    "MOTION_YPOSITION": "y апозициа",
+    "MOTION_DIRECTION": "ахырхарҭа",
     "SENSING_OF_COSTUMENUMBER": "акостиум №",
     "LOOKS_COSTUMENUMBERNAME": "акостиум %1",
-    "SENSING_OF_SIZE": "ашәагаа",
+    "LOOKS_SIZE": "ашәагаа",
     "SENSING_OF_BACKDROPNAME": "аҿаԥшыра ахьӡ",
     "LOOKS_BACKDROPNUMBERNAME": "аҿаԥшыра %1",
     "SENSING_OF_BACKDROPNUMBER": "аҿаԥшыра №",
@@ -256,6 +256,5 @@
     "10 ^"
   ],
   "aliases": {},
-  "name": "Аҧсшәа",
-  "percentTranslated": 100
+  "name": "Аҧсшәа"
 }

--- a/locales/af.json
+++ b/locales/af.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "verberg",
     "LOOKS_SWITCHCOSTUMETO": "ruil kostuum na %1",
     "LOOKS_NEXTCOSTUME": "volgende kostuum",
-    "LOOKS_NEXTBACKDROP_BLOCK": "volgende agtergrond",
+    "LOOKS_NEXTBACKDROP": "volgende agtergrond",
     "LOOKS_SWITCHBACKDROPTO": "ruil agtergrond na %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "ruil agtergrond na %1 en wag",
     "LOOKS_CHANGEEFFECTBY": "verander %1 effek met %2",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "vervang item %1 van %2 met %3",
     "DATA_SHOWLIST": "vertoon lys %1",
     "DATA_HIDELIST": "verberg lys %1",
-    "SENSING_OF_XPOSITION": "x posisie",
-    "SENSING_OF_YPOSITION": "y posisie",
-    "SENSING_OF_DIRECTION": "rigting",
+    "MOTION_XPOSITION": "x posisie",
+    "MOTION_YPOSITION": "y posisie",
+    "MOTION_DIRECTION": "rigting",
     "SENSING_OF_COSTUMENUMBER": "kostuum #",
     "LOOKS_COSTUMENUMBERNAME": "kostuum %1",
-    "SENSING_OF_SIZE": "grootte",
+    "LOOKS_SIZE": "grootte",
     "SENSING_OF_BACKDROPNAME": "agtergrondnaam",
     "LOOKS_BACKDROPNUMBERNAME": "agtergrond %1",
     "SENSING_OF_BACKDROPNUMBER": "agtergrond #",
@@ -256,6 +256,5 @@
     "10 ^"
   ],
   "aliases": {},
-  "name": "Afrikaans",
-  "percentTranslated": 100
+  "name": "Afrikaans"
 }

--- a/locales/am.json
+++ b/locales/am.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "ደብቅ",
     "LOOKS_SWITCHCOSTUMETO": "ልብስ ወደ %1 ለውጥ",
     "LOOKS_NEXTCOSTUME": "ቀጣይ አልባስ",
-    "LOOKS_NEXTBACKDROP_BLOCK": "ቀጣይ የጀርባ ምስል",
+    "LOOKS_NEXTBACKDROP": "ቀጣይ የጀርባ ምስል",
     "LOOKS_SWITCHBACKDROPTO": "የጀርባ ምስል ወደ %1 ለውጥ",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "የጀርባ ምስል ወደ %1 ለውጥና ጠብቅ",
     "LOOKS_CHANGEEFFECTBY": "%1ን ተጽኖ በ%2 ለውጥ",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "%1 ከ%2 ቀይር ወደ %3",
     "DATA_SHOWLIST": "%1ን ዝርዝር አሳይ",
     "DATA_HIDELIST": "%1ን ዝርዝር ደብቅ",
-    "SENSING_OF_XPOSITION": "x ቦታ",
-    "SENSING_OF_YPOSITION": "y ቦታ",
-    "SENSING_OF_DIRECTION": "አቅጣጫ",
+    "MOTION_XPOSITION": "x ቦታ",
+    "MOTION_YPOSITION": "y ቦታ",
+    "MOTION_DIRECTION": "አቅጣጫ",
     "SENSING_OF_COSTUMENUMBER": "ልብስ ቁጥር",
     "LOOKS_COSTUMENUMBERNAME": "ልብስ %1",
-    "SENSING_OF_SIZE": "መጠን",
+    "LOOKS_SIZE": "መጠን",
     "SENSING_OF_BACKDROPNAME": "የጀርባ ምስል ስም",
     "LOOKS_BACKDROPNUMBERNAME": "የጀርባ ምስል %1",
     "SENSING_OF_BACKDROPNUMBER": "የጀርባ ምስል #",
@@ -257,6 +257,5 @@
     "10 ^"
   ],
   "aliases": {},
-  "name": "አማርኛ",
-  "percentTranslated": 100
+  "name": "አማርኛ"
 }

--- a/locales/an.json
+++ b/locales/an.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "amagar",
     "LOOKS_SWITCHCOSTUMETO": "cambiar vestiu a %1",
     "LOOKS_NEXTCOSTUME": "siguient vestiu",
-    "LOOKS_NEXTBACKDROP_BLOCK": "siguient fondo",
+    "LOOKS_NEXTBACKDROP": "siguient fondo",
     "LOOKS_SWITCHBACKDROPTO": "cambiar fondo a %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "cambiar fondo a %1 y aguardar",
     "LOOKS_CHANGEEFFECTBY": "sumar %2 a l'efecto %1",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "reemplazar elemento %1 de %2 con %3",
     "DATA_SHOWLIST": "amostrar la lista %1",
     "DATA_HIDELIST": "amagar la lista %1",
-    "SENSING_OF_XPOSITION": "posición en x",
-    "SENSING_OF_YPOSITION": "posición en y",
-    "SENSING_OF_DIRECTION": "dirección",
+    "MOTION_XPOSITION": "posición en x",
+    "MOTION_YPOSITION": "posición en y",
+    "MOTION_DIRECTION": "dirección",
     "SENSING_OF_COSTUMENUMBER": "# de vestiu",
     "LOOKS_COSTUMENUMBERNAME": "%1 de vestiu",
-    "SENSING_OF_SIZE": "grandaria",
+    "LOOKS_SIZE": "grandaria",
     "SENSING_OF_BACKDROPNAME": "nombre de fondo",
     "LOOKS_BACKDROPNUMBERNAME": "%1 de fondo",
     "SENSING_OF_BACKDROPNUMBER": "# de fondo",
@@ -256,6 +256,5 @@
     "10 ^"
   ],
   "aliases": {},
-  "name": "Aragonés",
-  "percentTranslated": 100
+  "name": "Aragonés"
 }

--- a/locales/ar.json
+++ b/locales/ar.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "اختفِ",
     "LOOKS_SWITCHCOSTUMETO": "غيِّر المظهر إلى %1",
     "LOOKS_NEXTCOSTUME": "المظهر التالي",
-    "LOOKS_NEXTBACKDROP_BLOCK": "الخلفية التالية",
+    "LOOKS_NEXTBACKDROP": "الخلفية التالية",
     "LOOKS_SWITCHBACKDROPTO": "غيِّر الخلفية إلى %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "غيِّر الخلفية إلى %1 وانتظر",
     "LOOKS_CHANGEEFFECTBY": "غيّر مؤثر %1 بمقدار %2",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "استبدل %3 بالعنصر %1 من %2",
     "DATA_SHOWLIST": "أظهر اللائحة %1",
     "DATA_HIDELIST": "أخفِ اللائحة %1",
-    "SENSING_OF_XPOSITION": "الموضع س",
-    "SENSING_OF_YPOSITION": "الموضع ص",
-    "SENSING_OF_DIRECTION": "الاتجاه",
+    "MOTION_XPOSITION": "الموضع س",
+    "MOTION_YPOSITION": "الموضع ص",
+    "MOTION_DIRECTION": "الاتجاه",
     "SENSING_OF_COSTUMENUMBER": "رقم المظهر",
     "LOOKS_COSTUMENUMBERNAME": "%1 المظهر",
-    "SENSING_OF_SIZE": "الحجم",
+    "LOOKS_SIZE": "الحجم",
     "SENSING_OF_BACKDROPNAME": "اسم الخلفية",
     "LOOKS_BACKDROPNUMBERNAME": "%1 الخلفية",
     "SENSING_OF_BACKDROPNUMBER": "رقم الخلفية",
@@ -256,6 +256,5 @@
     "10^"
   ],
   "aliases": {},
-  "name": "العربية",
-  "percentTranslated": 100
+  "name": "العربية"
 }

--- a/locales/ast.json
+++ b/locales/ast.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "anubrir",
     "LOOKS_SWITCHCOSTUMETO": "cambiar disfraz a %1",
     "LOOKS_NEXTCOSTUME": "siguiente disfraz",
-    "LOOKS_NEXTBACKDROP_BLOCK": "siguiente fondu",
+    "LOOKS_NEXTBACKDROP": "siguiente fondu",
     "LOOKS_SWITCHBACKDROPTO": "cambiar fondu a %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "cambiar fondu a %1 y esperar",
     "LOOKS_CHANGEEFFECTBY": "cambiar l'efectu %1 por %2",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "sustituyir item %1 de %2 con %3",
     "DATA_SHOWLIST": "amosar llista %1",
     "DATA_HIDELIST": "anubrir llista %1",
-    "SENSING_OF_XPOSITION": "posición x",
-    "SENSING_OF_YPOSITION": "posición y",
-    "SENSING_OF_DIRECTION": "direición",
+    "MOTION_XPOSITION": "posición x",
+    "MOTION_YPOSITION": "posición y",
+    "MOTION_DIRECTION": "direición",
     "SENSING_OF_COSTUMENUMBER": "núm. de disfraz",
     "LOOKS_COSTUMENUMBERNAME": "disfraz %1",
-    "SENSING_OF_SIZE": "tamañu",
+    "LOOKS_SIZE": "tamañu",
     "SENSING_OF_BACKDROPNAME": "nombre de fondu",
     "LOOKS_BACKDROPNUMBERNAME": "fondu %1",
     "SENSING_OF_BACKDROPNUMBER": "núm. de fondu",
@@ -256,6 +256,5 @@
     "10 ^"
   ],
   "aliases": {},
-  "name": "Asturianu",
-  "percentTranslated": 100
+  "name": "Asturianu"
 }

--- a/locales/az.json
+++ b/locales/az.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "gizlən",
     "LOOKS_SWITCHCOSTUMETO": "%1 libasına dəyiş",
     "LOOKS_NEXTCOSTUME": "növbəti libas",
-    "LOOKS_NEXTBACKDROP_BLOCK": "növbəti fon",
+    "LOOKS_NEXTBACKDROP": "növbəti fon",
     "LOOKS_SWITCHBACKDROPTO": "%1 fonuna dəyiş",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "fonu %1 fonuna dəyiş və gözlə",
     "LOOKS_CHANGEEFFECTBY": "%1 effektini %2 qədər dəyiş",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "%1 elementini %2 siyahısında %3 ilə əvəz et",
     "DATA_SHOWLIST": "%1 siyahısını göstər",
     "DATA_HIDELIST": "%1 siyahısını gizlət",
-    "SENSING_OF_XPOSITION": "x mövqeyi",
-    "SENSING_OF_YPOSITION": "y mövqeyi",
-    "SENSING_OF_DIRECTION": "istiqamət",
+    "MOTION_XPOSITION": "x mövqeyi",
+    "MOTION_YPOSITION": "y mövqeyi",
+    "MOTION_DIRECTION": "istiqamət",
     "SENSING_OF_COSTUMENUMBER": "libas #",
     "LOOKS_COSTUMENUMBERNAME": "%1 libası",
-    "SENSING_OF_SIZE": "ölçü",
+    "LOOKS_SIZE": "ölçü",
     "SENSING_OF_BACKDROPNAME": "fonun adı",
     "LOOKS_BACKDROPNUMBERNAME": "%1 fonu",
     "SENSING_OF_BACKDROPNUMBER": "fon #",
@@ -257,6 +257,5 @@
     "10 ^"
   ],
   "aliases": {},
-  "name": "Azeri",
-  "percentTranslated": 100
+  "name": "Azeri"
 }

--- a/locales/be.json
+++ b/locales/be.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "схавацца",
     "LOOKS_SWITCHCOSTUMETO": "змяніць касцюм на %1",
     "LOOKS_NEXTCOSTUME": "наступны касцюм",
-    "LOOKS_NEXTBACKDROP_BLOCK": "наступны фон",
+    "LOOKS_NEXTBACKDROP": "наступны фон",
     "LOOKS_SWITCHBACKDROPTO": "змяніць фон на %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "змяніць фон на %1 і чакаць",
     "LOOKS_CHANGEEFFECTBY": "змяніць %1 эфект на %2",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "замяніць элемент %1 у %2 на %3",
     "DATA_SHOWLIST": "паказаць спіс %1",
     "DATA_HIDELIST": "схаваць спіс %1",
-    "SENSING_OF_XPOSITION": "пазіцыя X",
-    "SENSING_OF_YPOSITION": "пазіцыя Y",
-    "SENSING_OF_DIRECTION": "кірунак",
+    "MOTION_XPOSITION": "пазіцыя X",
+    "MOTION_YPOSITION": "пазіцыя Y",
+    "MOTION_DIRECTION": "кірунак",
     "SENSING_OF_COSTUMENUMBER": "касцюм #",
     "LOOKS_COSTUMENUMBERNAME": "касцюм %1",
-    "SENSING_OF_SIZE": "памер",
+    "LOOKS_SIZE": "памер",
     "SENSING_OF_BACKDROPNAME": "імя фону",
     "LOOKS_BACKDROPNUMBERNAME": "фон %1",
     "SENSING_OF_BACKDROPNUMBER": "фон #",
@@ -256,6 +256,5 @@
     "10 ^"
   ],
   "aliases": {},
-  "name": "Беларуская",
-  "percentTranslated": 100
+  "name": "Беларуская"
 }

--- a/locales/bg.json
+++ b/locales/bg.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "скрий се",
     "LOOKS_SWITCHCOSTUMETO": "промени костюм на %1",
     "LOOKS_NEXTCOSTUME": "следващ костюм",
-    "LOOKS_NEXTBACKDROP_BLOCK": "следващ декор",
+    "LOOKS_NEXTBACKDROP": "следващ декор",
     "LOOKS_SWITCHBACKDROPTO": "смени декора с %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "смени декора с %1 и чакай",
     "LOOKS_CHANGEEFFECTBY": "промени ефект %1  с %2",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "замени елемент %1 от %2 с %3",
     "DATA_SHOWLIST": "покажи списък %1",
     "DATA_HIDELIST": "скрий списък %1",
-    "SENSING_OF_XPOSITION": "x позиция",
-    "SENSING_OF_YPOSITION": "y позиция",
-    "SENSING_OF_DIRECTION": "посока",
+    "MOTION_XPOSITION": "x позиция",
+    "MOTION_YPOSITION": "y позиция",
+    "MOTION_DIRECTION": "посока",
     "SENSING_OF_COSTUMENUMBER": "костюм #",
     "LOOKS_COSTUMENUMBERNAME": "костюм %1",
-    "SENSING_OF_SIZE": "размер",
+    "LOOKS_SIZE": "размер",
     "SENSING_OF_BACKDROPNAME": "име на декор",
     "LOOKS_BACKDROPNUMBERNAME": "декор %1",
     "SENSING_OF_BACKDROPNUMBER": "декор #",
@@ -256,6 +256,5 @@
     "10 ^"
   ],
   "aliases": {},
-  "name": "Български",
-  "percentTranslated": 100
+  "name": "Български"
 }

--- a/locales/bn.json
+++ b/locales/bn.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "লুকাও",
     "LOOKS_SWITCHCOSTUMETO": "পোশাক %1 এ পরিবর্তন কর",
     "LOOKS_NEXTCOSTUME": "পরবর্তী পোশাক",
-    "LOOKS_NEXTBACKDROP_BLOCK": "পরবর্তী ব্যাকড্রপ",
+    "LOOKS_NEXTBACKDROP": "পরবর্তী ব্যাকড্রপ",
     "LOOKS_SWITCHBACKDROPTO": "ব্যাকড্রপ %1 এ পরিবর্তন কর",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "ব্যাকড্রপ %1 এ পরিবর্তন করে অপেক্ষা কর",
     "LOOKS_CHANGEEFFECTBY": "%1 এর ইফেক্ট %2 পরিবর্তন কর",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "%2 এর %1 আইটেমকে %3 দ্বারা প্রতিস্থাপন কর",
     "DATA_SHOWLIST": "%1 তালিকা প্রদর্শন কর",
     "DATA_HIDELIST": "%1 তালিকা লুকাও",
-    "SENSING_OF_XPOSITION": "x এর অবস্থান",
-    "SENSING_OF_YPOSITION": "y এর অবস্থান",
-    "SENSING_OF_DIRECTION": "দিক",
+    "MOTION_XPOSITION": "x এর অবস্থান",
+    "MOTION_YPOSITION": "y এর অবস্থান",
+    "MOTION_DIRECTION": "দিক",
     "SENSING_OF_COSTUMENUMBER": "পোশাক #",
     "LOOKS_COSTUMENUMBERNAME": "পোশাক %1",
-    "SENSING_OF_SIZE": "আকার",
+    "LOOKS_SIZE": "আকার",
     "SENSING_OF_BACKDROPNAME": "ব্যাকড্রপের নাম",
     "LOOKS_BACKDROPNUMBERNAME": "ব্যাকড্রপ %1",
     "SENSING_OF_BACKDROPNUMBER": "ব্যাকড্রপ #",
@@ -256,6 +256,5 @@
     "10 ^"
   ],
   "aliases": {},
-  "name": "বাংলা",
-  "percentTranslated": 100
+  "name": "বাংলা"
 }

--- a/locales/ca.json
+++ b/locales/ca.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "amaga't",
     "LOOKS_SWITCHCOSTUMETO": "canvia el vestit a %1",
     "LOOKS_NEXTCOSTUME": "següent vestit",
-    "LOOKS_NEXTBACKDROP_BLOCK": "següent fons de pantalla",
+    "LOOKS_NEXTBACKDROP": "següent fons de pantalla",
     "LOOKS_SWITCHBACKDROPTO": "canvia el fons a %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "canvia el fons a %1 i espera",
     "LOOKS_CHANGEEFFECTBY": "augmenta l'efecte %1 en %2",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "canvia l'element %1 de %2 per %3",
     "DATA_SHOWLIST": "mostra la llista %1",
     "DATA_HIDELIST": "amaga la llista %1",
-    "SENSING_OF_XPOSITION": "posició x",
-    "SENSING_OF_YPOSITION": "posició y",
-    "SENSING_OF_DIRECTION": "direcció",
+    "MOTION_XPOSITION": "posició x",
+    "MOTION_YPOSITION": "posició y",
+    "MOTION_DIRECTION": "direcció",
     "SENSING_OF_COSTUMENUMBER": "vestit nr",
     "LOOKS_COSTUMENUMBERNAME": "vestit %1",
-    "SENSING_OF_SIZE": "mida",
+    "LOOKS_SIZE": "mida",
     "SENSING_OF_BACKDROPNAME": "nom del fons",
     "LOOKS_BACKDROPNUMBERNAME": "fons %1",
     "SENSING_OF_BACKDROPNUMBER": "fons nr",
@@ -262,6 +262,5 @@
     "quan la bandera verda es premi": "EVENT_WHENFLAGCLICKED",
     "fi": "scratchblocks:end"
   },
-  "name": "Català",
-  "percentTranslated": 100
+  "name": "Català"
 }

--- a/locales/ckb.json
+++ b/locales/ckb.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "شاردنەوە",
     "LOOKS_SWITCHCOSTUMETO": "گۆڕینی بەرگ بۆ %1",
     "LOOKS_NEXTCOSTUME": "بەرگی دواتر",
-    "LOOKS_NEXTBACKDROP_BLOCK": "پاشبنەمای دواتر",
+    "LOOKS_NEXTBACKDROP": "پاشبنەمای دواتر",
     "LOOKS_SWITCHBACKDROPTO": "گۆڕینی پاشبنەما بۆ %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "گۆڕینی پاشبنەما بۆ %1 و چاوەڕێ بکە",
     "LOOKS_CHANGEEFFECTBY": "گۆڕینی %1 کاریگەری بە %2",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "گۆڕینەوەی دانە %1 لە %2 لەگەڵ %3",
     "DATA_SHOWLIST": "پیشاندانی لیست %1",
     "DATA_HIDELIST": "شاردنەوەی لیست %1",
-    "SENSING_OF_XPOSITION": "شوێنی x",
-    "SENSING_OF_YPOSITION": "شوێنی y",
-    "SENSING_OF_DIRECTION": "ئاڕاستە",
+    "MOTION_XPOSITION": "شوێنی x",
+    "MOTION_YPOSITION": "شوێنی y",
+    "MOTION_DIRECTION": "ئاڕاستە",
     "SENSING_OF_COSTUMENUMBER": "بەرگ #",
     "LOOKS_COSTUMENUMBERNAME": "بەرگ %1",
-    "SENSING_OF_SIZE": "قەبارە",
+    "LOOKS_SIZE": "قەبارە",
     "SENSING_OF_BACKDROPNAME": "ناوی پاشبنەما",
     "LOOKS_BACKDROPNUMBERNAME": "پاشبنه‌ما %1",
     "SENSING_OF_BACKDROPNUMBER": "پاشبنه‌ما #",
@@ -256,6 +256,5 @@
     "10 ^"
   ],
   "aliases": {},
-  "name": "کوردیی ناوەندی",
-  "percentTranslated": 100
+  "name": "کوردیی ناوەندی"
 }

--- a/locales/cs.json
+++ b/locales/cs.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "skryj se",
     "LOOKS_SWITCHCOSTUMETO": "změň kostým na %1",
     "LOOKS_NEXTCOSTUME": "další kostým",
-    "LOOKS_NEXTBACKDROP_BLOCK": "další pozadí",
+    "LOOKS_NEXTBACKDROP": "další pozadí",
     "LOOKS_SWITCHBACKDROPTO": "přepni pozadí na %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "změň pozadí na %1",
     "LOOKS_CHANGEEFFECTBY": "změň efekt %1 o %2",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "nahraď %1 v %2 hodnotou %3",
     "DATA_SHOWLIST": "ukaž seznam %1",
     "DATA_HIDELIST": "skryj seznam %1",
-    "SENSING_OF_XPOSITION": "x",
-    "SENSING_OF_YPOSITION": "y",
-    "SENSING_OF_DIRECTION": "směr",
+    "MOTION_XPOSITION": "x",
+    "MOTION_YPOSITION": "y",
+    "MOTION_DIRECTION": "směr",
     "SENSING_OF_COSTUMENUMBER": "číslo kostýmu",
     "LOOKS_COSTUMENUMBERNAME": "kostým %1",
-    "SENSING_OF_SIZE": "velikost",
+    "LOOKS_SIZE": "velikost",
     "SENSING_OF_BACKDROPNAME": "název pozadí",
     "LOOKS_BACKDROPNUMBERNAME": "pozadí %1",
     "SENSING_OF_BACKDROPNUMBER": "číslo pozadí",
@@ -262,6 +262,5 @@
     "po kliknutí na zelenou vlajku": "EVENT_WHENFLAGCLICKED",
     "konec": "scratchblocks:end"
   },
-  "name": "Česky",
-  "percentTranslated": 100
+  "name": "Česky"
 }

--- a/locales/cy.json
+++ b/locales/cy.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "cuddio",
     "LOOKS_SWITCHCOSTUMETO": "newid gwisg i %1",
     "LOOKS_NEXTCOSTUME": "gwisg nesaf",
-    "LOOKS_NEXTBACKDROP_BLOCK": "cefnlen nesaf",
+    "LOOKS_NEXTBACKDROP": "cefnlen nesaf",
     "LOOKS_SWITCHBACKDROPTO": "newid cefndir i %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "newid cefnlen i %1 ac aros",
     "LOOKS_CHANGEEFFECTBY": "newid effaith %1 gan %2",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "amnewid eitem %1 o %2 gyda %3",
     "DATA_SHOWLIST": "dangos rhestr %1",
     "DATA_HIDELIST": "cuddio rhestr %1",
-    "SENSING_OF_XPOSITION": "safle x",
-    "SENSING_OF_YPOSITION": "safle y",
-    "SENSING_OF_DIRECTION": "cyfeiriad",
+    "MOTION_XPOSITION": "safle x",
+    "MOTION_YPOSITION": "safle y",
+    "MOTION_DIRECTION": "cyfeiriad",
     "SENSING_OF_COSTUMENUMBER": "gwisg #",
     "LOOKS_COSTUMENUMBERNAME": "gwisg %1",
-    "SENSING_OF_SIZE": "maint",
+    "LOOKS_SIZE": "maint",
     "SENSING_OF_BACKDROPNAME": "enw cefnlen",
     "LOOKS_BACKDROPNUMBERNAME": "cefnlen %1",
     "SENSING_OF_BACKDROPNUMBER": "cefnlen #",
@@ -261,6 +261,5 @@
     "pan fo'r flag werdd yn cael ei glicio": "EVENT_WHENFLAGCLICKED",
     "diwedd": "scratchblocks:end"
   },
-  "name": "Cymraeg",
-  "percentTranslated": 100
+  "name": "Cymraeg"
 }

--- a/locales/da.json
+++ b/locales/da.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "skjul",
     "LOOKS_SWITCHCOSTUMETO": "skift kostume til %1",
     "LOOKS_NEXTCOSTUME": "næste kostume",
-    "LOOKS_NEXTBACKDROP_BLOCK": "næste baggrund",
+    "LOOKS_NEXTBACKDROP": "næste baggrund",
     "LOOKS_SWITCHBACKDROPTO": "skift baggrund til %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "skift baggrund til %1 og vent",
     "LOOKS_CHANGEEFFECTBY": "ændre effekt %1 med %2",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "erstat nummer %1 af %2 med %3",
     "DATA_SHOWLIST": "vis liste %1",
     "DATA_HIDELIST": "skjul liste %1",
-    "SENSING_OF_XPOSITION": "x position",
-    "SENSING_OF_YPOSITION": "y position",
-    "SENSING_OF_DIRECTION": "retning",
+    "MOTION_XPOSITION": "x position",
+    "MOTION_YPOSITION": "y position",
+    "MOTION_DIRECTION": "retning",
     "SENSING_OF_COSTUMENUMBER": "kostume #",
     "LOOKS_COSTUMENUMBERNAME": "kostume %1",
-    "SENSING_OF_SIZE": "størrelse",
+    "LOOKS_SIZE": "størrelse",
     "SENSING_OF_BACKDROPNAME": "navn på baggrund",
     "LOOKS_BACKDROPNUMBERNAME": "baggrund %1",
     "SENSING_OF_BACKDROPNUMBER": "baggrund #",
@@ -256,6 +256,5 @@
     "10 ^"
   ],
   "aliases": {},
-  "name": "Dansk",
-  "percentTranslated": 100
+  "name": "Dansk"
 }

--- a/locales/de.json
+++ b/locales/de.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "verstecke dich",
     "LOOKS_SWITCHCOSTUMETO": "wechsle zu Kostüm %1",
     "LOOKS_NEXTCOSTUME": "wechsle zum nächsten Kostüm",
-    "LOOKS_NEXTBACKDROP_BLOCK": "wechsle zum nächsten Bühnenbild",
+    "LOOKS_NEXTBACKDROP": "nächstes Bühnenbild",
     "LOOKS_SWITCHBACKDROPTO": "wechsle zu Bühnenbild %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "wechsle zu Bühnenbild %1 und warte",
     "LOOKS_CHANGEEFFECTBY": "ändere Effekt %1 um %2",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "ersetze Element %1 von %2 durch %3",
     "DATA_SHOWLIST": "zeige Liste %1",
     "DATA_HIDELIST": "verstecke Liste %1",
-    "SENSING_OF_XPOSITION": "x-Position",
-    "SENSING_OF_YPOSITION": "y-Position",
-    "SENSING_OF_DIRECTION": "Richtung",
+    "MOTION_XPOSITION": "x-Position",
+    "MOTION_YPOSITION": "y-Position",
+    "MOTION_DIRECTION": "Richtung",
     "SENSING_OF_COSTUMENUMBER": "Kostümnummer",
     "LOOKS_COSTUMENUMBERNAME": "Kostüm %1",
-    "SENSING_OF_SIZE": "Größe",
+    "LOOKS_SIZE": "Größe",
     "SENSING_OF_BACKDROPNAME": "Bühnenbildname",
     "LOOKS_BACKDROPNUMBERNAME": "Bühnenbild %1",
     "SENSING_OF_BACKDROPNUMBER": "Bühnenbildnummer",
@@ -261,6 +261,5 @@
     "Wenn die grüne Flagge angeklickt": "EVENT_WHENFLAGCLICKED",
     "Ende": "scratchblocks:end"
   },
-  "name": "Deutsch",
-  "percentTranslated": 100
+  "name": "Deutsch"
 }

--- a/locales/el.json
+++ b/locales/el.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "εξαφανίσου",
     "LOOKS_SWITCHCOSTUMETO": "άλλαξε ενδυμασία σε %1",
     "LOOKS_NEXTCOSTUME": "επόμενη ενδυμασία",
-    "LOOKS_NEXTBACKDROP_BLOCK": "επόμενο υπόβαθρο",
+    "LOOKS_NEXTBACKDROP": "επόμενο υπόβαθρο",
     "LOOKS_SWITCHBACKDROPTO": "άλλαξε υπόβαθρο σε %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "άλλαξε υπόβαθρο σε %1 και περίμενε",
     "LOOKS_CHANGEEFFECTBY": "άλλαξε εφέ %1 κατά %2",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "αντικατάστησε στοιχείο %1 λίστας %2 με %3",
     "DATA_SHOWLIST": "εμφάνισε λίστα %1",
     "DATA_HIDELIST": "απόκρυψε λίστα %1",
-    "SENSING_OF_XPOSITION": "θέση x",
-    "SENSING_OF_YPOSITION": "θέση y",
-    "SENSING_OF_DIRECTION": "κατεύθυνση",
+    "MOTION_XPOSITION": "θέση x",
+    "MOTION_YPOSITION": "θέση y",
+    "MOTION_DIRECTION": "κατεύθυνση",
     "SENSING_OF_COSTUMENUMBER": "# ενδυμασίας",
     "LOOKS_COSTUMENUMBERNAME": "ενδυμασία %1",
-    "SENSING_OF_SIZE": "μέγεθος",
+    "LOOKS_SIZE": "μέγεθος",
     "SENSING_OF_BACKDROPNAME": "όνομα υποβάθρου",
     "LOOKS_BACKDROPNUMBERNAME": "υπόβαθρο %1",
     "SENSING_OF_BACKDROPNUMBER": "# υποβάθρου",
@@ -263,6 +263,5 @@
     "Όταν στην πράσινη σημαία γίνει κλικ": "EVENT_WHENFLAGCLICKED",
     "τέλος": "scratchblocks:end"
   },
-  "name": "Ελληνικά",
-  "percentTranslated": 100
+  "name": "Ελληνικά"
 }

--- a/locales/eo.json
+++ b/locales/eo.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "kaŝi",
     "LOOKS_SWITCHCOSTUMETO": "ŝanĝi al la kostumo %1",
     "LOOKS_NEXTCOSTUME": "sekva kostumo",
-    "LOOKS_NEXTBACKDROP_BLOCK": "sekva fono",
+    "LOOKS_NEXTBACKDROP": "sekva fono",
     "LOOKS_SWITCHBACKDROPTO": "ŝanĝi fonon al %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "ŝanĝi fonon al %1 kaj atendi",
     "LOOKS_CHANGEEFFECTBY": "ŝanĝi efikon %1 je %2",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "anstataŭigi %1-an eron de %2 per %3",
     "DATA_SHOWLIST": "montri liston %1",
     "DATA_HIDELIST": "kaŝi liston %1",
-    "SENSING_OF_XPOSITION": "x-pozicio",
-    "SENSING_OF_YPOSITION": "y-pozicio",
-    "SENSING_OF_DIRECTION": "direkto",
+    "MOTION_XPOSITION": "x-pozicio",
+    "MOTION_YPOSITION": "y-pozicio",
+    "MOTION_DIRECTION": "direkto",
     "SENSING_OF_COSTUMENUMBER": "numero de kostumo",
     "LOOKS_COSTUMENUMBERNAME": "%1 de kostumo",
-    "SENSING_OF_SIZE": "grando",
+    "LOOKS_SIZE": "grando",
     "SENSING_OF_BACKDROPNAME": "nomo de fono",
     "LOOKS_BACKDROPNUMBERNAME": "%1 de fono",
     "SENSING_OF_BACKDROPNUMBER": "numero de la fono",
@@ -256,6 +256,5 @@
     "10 ^"
   ],
   "aliases": {},
-  "name": "Esperanto",
-  "percentTranslated": 100
+  "name": "Esperanto"
 }

--- a/locales/es-419.json
+++ b/locales/es-419.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "esconder",
     "LOOKS_SWITCHCOSTUMETO": "cambiar disfraz a %1",
     "LOOKS_NEXTCOSTUME": "siguiente disfraz",
-    "LOOKS_NEXTBACKDROP_BLOCK": "siguiente fondo",
+    "LOOKS_NEXTBACKDROP": "siguiente fondo",
     "LOOKS_SWITCHBACKDROPTO": "cambiar fondo a %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "cambiar fondo a %1 y esperar",
     "LOOKS_CHANGEEFFECTBY": "cambiar el efecto %1 en %2",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "reemplazar elemento %1 de %2 con %3",
     "DATA_SHOWLIST": "mostrar lista %1",
     "DATA_HIDELIST": "esconder lista %1",
-    "SENSING_OF_XPOSITION": "posición en x",
-    "SENSING_OF_YPOSITION": "posición en y",
-    "SENSING_OF_DIRECTION": "dirección",
+    "MOTION_XPOSITION": "posición en x",
+    "MOTION_YPOSITION": "posición en y",
+    "MOTION_DIRECTION": "dirección",
     "SENSING_OF_COSTUMENUMBER": "# de disfraz",
     "LOOKS_COSTUMENUMBERNAME": "disfraz %1",
-    "SENSING_OF_SIZE": "tamaño",
+    "LOOKS_SIZE": "tamaño",
     "SENSING_OF_BACKDROPNAME": "nombre de fondo",
     "LOOKS_BACKDROPNUMBERNAME": "fondo %1",
     "SENSING_OF_BACKDROPNUMBER": "# de fondo",
@@ -256,6 +256,5 @@
     "10 ^"
   ],
   "aliases": {},
-  "name": "Español Latinoamericano",
-  "percentTranslated": 100
+  "name": "Español Latinoamericano"
 }

--- a/locales/es.json
+++ b/locales/es.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "esconder",
     "LOOKS_SWITCHCOSTUMETO": "cambiar disfraz a %1",
     "LOOKS_NEXTCOSTUME": "siguiente disfraz",
-    "LOOKS_NEXTBACKDROP_BLOCK": "siguiente fondo",
+    "LOOKS_NEXTBACKDROP": "siguiente fondo",
     "LOOKS_SWITCHBACKDROPTO": "cambiar fondo a %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "cambiar fondo a %1 y esperar",
     "LOOKS_CHANGEEFFECTBY": "sumar al efecto %1 %2",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "reemplazar elemento %1 de %2 con %3",
     "DATA_SHOWLIST": "mostrar lista %1",
     "DATA_HIDELIST": "esconder lista %1",
-    "SENSING_OF_XPOSITION": "posición en x",
-    "SENSING_OF_YPOSITION": "posición en y",
-    "SENSING_OF_DIRECTION": "dirección",
+    "MOTION_XPOSITION": "posición en x",
+    "MOTION_YPOSITION": "posición en y",
+    "MOTION_DIRECTION": "dirección",
     "SENSING_OF_COSTUMENUMBER": "# de disfraz",
     "LOOKS_COSTUMENUMBERNAME": "%1 de disfraz",
-    "SENSING_OF_SIZE": "tamaño",
+    "LOOKS_SIZE": "tamaño",
     "SENSING_OF_BACKDROPNAME": "nombre de fondo",
     "LOOKS_BACKDROPNUMBERNAME": "%1 de fondo",
     "SENSING_OF_BACKDROPNUMBER": "# de fondo",
@@ -261,6 +261,5 @@
     "al presionar bandera verde": "EVENT_WHENFLAGCLICKED",
     "fin": "scratchblocks:end"
   },
-  "name": "Español (España)",
-  "percentTranslated": 100
+  "name": "Español (España)"
 }

--- a/locales/et.json
+++ b/locales/et.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "peida",
     "LOOKS_SWITCHCOSTUMETO": "võta kostüüm %1",
     "LOOKS_NEXTCOSTUME": "järgmine kostüüm",
-    "LOOKS_NEXTBACKDROP_BLOCK": "järgmine taust",
+    "LOOKS_NEXTBACKDROP": "järgmine taust",
     "LOOKS_SWITCHBACKDROPTO": "võta taust %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "võta taust %1 ja oota",
     "LOOKS_CHANGEEFFECTBY": "muuda efekti %1 %2 võrra",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "asenda väärtus %1 loendis %2 %3 -ga",
     "DATA_SHOWLIST": "näita loendit %1",
     "DATA_HIDELIST": "peida loend %1",
-    "SENSING_OF_XPOSITION": "x",
-    "SENSING_OF_YPOSITION": "y",
-    "SENSING_OF_DIRECTION": "suund",
+    "MOTION_XPOSITION": "x",
+    "MOTION_YPOSITION": "y",
+    "MOTION_DIRECTION": "suund",
     "SENSING_OF_COSTUMENUMBER": "kostüümi nr",
     "LOOKS_COSTUMENUMBERNAME": "kostüümi %1",
-    "SENSING_OF_SIZE": "suurus",
+    "LOOKS_SIZE": "suurus",
     "SENSING_OF_BACKDROPNAME": "tausta nimi",
     "LOOKS_BACKDROPNUMBERNAME": "tausta %1",
     "SENSING_OF_BACKDROPNUMBER": "tausta nr",
@@ -256,6 +256,5 @@
     "10 ^"
   ],
   "aliases": {},
-  "name": "Eesti",
-  "percentTranslated": 100
+  "name": "Eesti"
 }

--- a/locales/eu.json
+++ b/locales/eu.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "ezkutatu",
     "LOOKS_SWITCHCOSTUMETO": "aldatu tankera %1 ra",
     "LOOKS_NEXTCOSTUME": "hurrengo tankera",
-    "LOOKS_NEXTBACKDROP_BLOCK": "hurrengo atzeko oihala",
+    "LOOKS_NEXTBACKDROP": "hurrengo atzeko oihala",
     "LOOKS_SWITCHBACKDROPTO": "aldatu atzeko oihala %1 ra",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "aldatu atzeko oihala %1 ra eta itxaron",
     "LOOKS_CHANGEEFFECTBY": "aldatu %1 efektua %2 unitate",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "aldatu %2 -ko %1 elementua %3 -rekin",
     "DATA_SHOWLIST": "erakutsi %1 zerrenda",
     "DATA_HIDELIST": "ezkutatu %1 zerrenda",
-    "SENSING_OF_XPOSITION": "x kokapena",
-    "SENSING_OF_YPOSITION": "y kokapena",
-    "SENSING_OF_DIRECTION": "norabidea",
+    "MOTION_XPOSITION": "x kokapena",
+    "MOTION_YPOSITION": "y kokapena",
+    "MOTION_DIRECTION": "norabidea",
     "SENSING_OF_COSTUMENUMBER": "# tankera",
     "LOOKS_COSTUMENUMBERNAME": "%1 tankera",
-    "SENSING_OF_SIZE": "tamaina",
+    "LOOKS_SIZE": "tamaina",
     "SENSING_OF_BACKDROPNAME": "atzeko oihalaren izena",
     "LOOKS_BACKDROPNUMBERNAME": "%1 atzeko oihala",
     "SENSING_OF_BACKDROPNUMBER": "# atzeko oihala",
@@ -256,6 +256,5 @@
     "10 ^"
   ],
   "aliases": {},
-  "name": "Euskara",
-  "percentTranslated": 100
+  "name": "Euskara"
 }

--- a/locales/fa.json
+++ b/locales/fa.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "پنهان شو",
     "LOOKS_SWITCHCOSTUMETO": "تغییر حالت به %1",
     "LOOKS_NEXTCOSTUME": "حالت بعدی",
-    "LOOKS_NEXTBACKDROP_BLOCK": "پس‌زمینه‌ی بعدی",
+    "LOOKS_NEXTBACKDROP": "پس‌زمینه‌ی بعدی",
     "LOOKS_SWITCHBACKDROPTO": "تغییر پس‌زمینه به %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "تغییر پس‌زمینه به %1 و منتظر بمان",
     "LOOKS_CHANGEEFFECTBY": "تغییر جلوه‌ی %1 به اندازه %2 تا",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "جایگزینی ردیف %1 %2 با %3",
     "DATA_SHOWLIST": "لیست %1 را نمایش بده",
     "DATA_HIDELIST": "لیست %1 را پنهان کن",
-    "SENSING_OF_XPOSITION": "مکان x",
-    "SENSING_OF_YPOSITION": "مکان y",
-    "SENSING_OF_DIRECTION": "جهت",
+    "MOTION_XPOSITION": "مکان x",
+    "MOTION_YPOSITION": "مکان y",
+    "MOTION_DIRECTION": "جهت",
     "SENSING_OF_COSTUMENUMBER": "# حالت",
     "LOOKS_COSTUMENUMBERNAME": "%1 حالت",
-    "SENSING_OF_SIZE": "اندازه‌ی",
+    "LOOKS_SIZE": "اندازه",
     "SENSING_OF_BACKDROPNAME": "نام پس‌زمینه‌ی",
     "LOOKS_BACKDROPNUMBERNAME": "%1 پس‌زمینه‌",
     "SENSING_OF_BACKDROPNUMBER": "# پس‌زمینه‌ی",
@@ -261,6 +261,5 @@
     "وقتی که پرچم کلیک شد": "EVENT_WHENFLAGCLICKED",
     "آخر": "scratchblocks:end"
   },
-  "name": "فارسی",
-  "percentTranslated": 100
+  "name": "فارسی"
 }

--- a/locales/fi.json
+++ b/locales/fi.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "piilota",
     "LOOKS_SWITCHCOSTUMETO": "vaihda asusteeksi %1",
     "LOOKS_NEXTCOSTUME": "seuraava asuste",
-    "LOOKS_NEXTBACKDROP_BLOCK": "seuraava tausta",
+    "LOOKS_NEXTBACKDROP": "seuraava tausta",
     "LOOKS_SWITCHBACKDROPTO": "vaihda taustaksi %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "vaihda taustaksi %1 ja odota",
     "LOOKS_CHANGEEFFECTBY": "lisää %1 tehostetta arvolla %2",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "korvaa listan %2 kohdan %1 arvo arvolla %3",
     "DATA_SHOWLIST": "näytä lista %1",
     "DATA_HIDELIST": "piilota lista %1",
-    "SENSING_OF_XPOSITION": "x-sijainti",
-    "SENSING_OF_YPOSITION": "y-sijainti",
-    "SENSING_OF_DIRECTION": "suunta",
+    "MOTION_XPOSITION": "x-sijainti",
+    "MOTION_YPOSITION": "y-sijainti",
+    "MOTION_DIRECTION": "suunta",
     "SENSING_OF_COSTUMENUMBER": "asusteen numero",
     "LOOKS_COSTUMENUMBERNAME": "asuste %1",
-    "SENSING_OF_SIZE": "koko",
+    "LOOKS_SIZE": "koko",
     "SENSING_OF_BACKDROPNAME": "taustan nimi",
     "LOOKS_BACKDROPNUMBERNAME": "tausta %1",
     "SENSING_OF_BACKDROPNUMBER": "taustan numero",
@@ -256,6 +256,5 @@
     "10 ^"
   ],
   "aliases": {},
-  "name": "Suomi",
-  "percentTranslated": 100
+  "name": "Suomi"
 }

--- a/locales/fil.json
+++ b/locales/fil.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "itago",
     "LOOKS_SWITCHCOSTUMETO": "palitan ang costume ng %1",
     "LOOKS_NEXTCOSTUME": "susunod na costume",
-    "LOOKS_NEXTBACKDROP_BLOCK": "susunod na likod",
+    "LOOKS_NEXTBACKDROP": "susunod na likod",
     "LOOKS_SWITCHBACKDROPTO": "palitan ang likod ng %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "palitan ang likod ng %1 at maghintay",
     "LOOKS_CHANGEEFFECTBY": "baguhin ang epektong %1 nang %2",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "palitan ang item na %1 ng %2 ng %3",
     "DATA_SHOWLIST": "ipakita ang listahan na %1",
     "DATA_HIDELIST": "itago ang listahan na %1",
-    "SENSING_OF_XPOSITION": "posisyong x",
-    "SENSING_OF_YPOSITION": "posisyong y",
-    "SENSING_OF_DIRECTION": "direksyon",
+    "MOTION_XPOSITION": "posisyong x",
+    "MOTION_YPOSITION": "posisyong y",
+    "MOTION_DIRECTION": "direksyon",
     "SENSING_OF_COSTUMENUMBER": "costume #",
     "LOOKS_COSTUMENUMBERNAME": "costume na %1",
-    "SENSING_OF_SIZE": "laki",
+    "LOOKS_SIZE": "laki",
     "SENSING_OF_BACKDROPNAME": "pangalan ng likod",
     "LOOKS_BACKDROPNUMBERNAME": "likod na %1",
     "SENSING_OF_BACKDROPNUMBER": "likod #",
@@ -257,6 +257,5 @@
     "10 ^"
   ],
   "aliases": {},
-  "name": "Filipino",
-  "percentTranslated": 100
+  "name": "Filipino"
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "cacher",
     "LOOKS_SWITCHCOSTUMETO": "basculer sur le costume %1",
     "LOOKS_NEXTCOSTUME": "costume suivant",
-    "LOOKS_NEXTBACKDROP_BLOCK": "arrière-plan suivant",
+    "LOOKS_NEXTBACKDROP": "arrière-plan suivant",
     "LOOKS_SWITCHBACKDROPTO": "basculer sur l'arrière-plan %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "basculer sur l'arrière-plan %1 et attendre",
     "LOOKS_CHANGEEFFECTBY": "ajouter %2 à l'effet %1",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "remplacer l'élément %1 de la liste %2 par %3",
     "DATA_SHOWLIST": "montrer la liste %1",
     "DATA_HIDELIST": "cacher la liste %1",
-    "SENSING_OF_XPOSITION": "abscisse x",
-    "SENSING_OF_YPOSITION": "ordonnée y",
-    "SENSING_OF_DIRECTION": "direction",
+    "MOTION_XPOSITION": "abscisse x",
+    "MOTION_YPOSITION": "ordonnée y",
+    "MOTION_DIRECTION": "direction",
     "SENSING_OF_COSTUMENUMBER": "numéro de costume",
     "LOOKS_COSTUMENUMBERNAME": "%1 du costume",
-    "SENSING_OF_SIZE": "taille",
+    "LOOKS_SIZE": "taille",
     "SENSING_OF_BACKDROPNAME": "nom de l'arrière-plan",
     "LOOKS_BACKDROPNUMBERNAME": "%1 de l'arrière-plan",
     "SENSING_OF_BACKDROPNUMBER": "numéro de l'arrière-plan",
@@ -261,6 +261,5 @@
     "quand le drapeau vert pressé": "EVENT_WHENFLAGCLICKED",
     "fin": "scratchblocks:end"
   },
-  "name": "Français",
-  "percentTranslated": 100
+  "name": "Français"
 }

--- a/locales/fy.json
+++ b/locales/fy.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "ferstopje",
     "LOOKS_SWITCHCOSTUMETO": "wikselje kostúm nei %1",
     "LOOKS_NEXTCOSTUME": "folgjende kostúm",
-    "LOOKS_NEXTBACKDROP_BLOCK": "folgjende dekôr",
+    "LOOKS_NEXTBACKDROP": "folgjende dekôr",
     "LOOKS_SWITCHBACKDROPTO": "wikselje eftergrûn nei %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "wikselje dekôr nei %1 en wachtsje",
     "LOOKS_CHANGEEFFECTBY": "feroarje %1 effekt mei %2",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "ferfang ûnderdiel %1 fan %2 troch %3",
     "DATA_SHOWLIST": "list %1 sjen litte",
     "DATA_HIDELIST": "list %1 ferbergje",
-    "SENSING_OF_XPOSITION": "posysje fan x",
-    "SENSING_OF_YPOSITION": "posysje fan y",
-    "SENSING_OF_DIRECTION": "rjochting",
+    "MOTION_XPOSITION": "x posysje",
+    "MOTION_YPOSITION": "y posysje",
+    "MOTION_DIRECTION": "rjochting",
     "SENSING_OF_COSTUMENUMBER": "kostúm #",
     "LOOKS_COSTUMENUMBERNAME": "kostúm %1",
-    "SENSING_OF_SIZE": "grutte",
+    "LOOKS_SIZE": "grutte",
     "SENSING_OF_BACKDROPNAME": "eftergrûn namme",
     "LOOKS_BACKDROPNUMBERNAME": "eftergrûn %1",
     "SENSING_OF_BACKDROPNUMBER": "eftergrûn #",
@@ -256,6 +256,5 @@
     "10 ^"
   ],
   "aliases": {},
-  "name": "Frysk",
-  "percentTranslated": 100
+  "name": "Frysk"
 }

--- a/locales/ga.json
+++ b/locales/ga.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "folaigh",
     "LOOKS_SWITCHCOSTUMETO": "athraigh an chulaith go %1",
     "LOOKS_NEXTCOSTUME": "an chéad chulaith eile",
-    "LOOKS_NEXTBACKDROP_BLOCK": "an chéad chúlra eile",
+    "LOOKS_NEXTBACKDROP": "an chéad chúlra eile",
     "LOOKS_SWITCHBACKDROPTO": "athraigh an cúlra go %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "athraigh an cúlra go %1 agus fan",
     "LOOKS_CHANGEEFFECTBY": "athraigh maisíocht %1 de %2",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "cuir %3 in áit mír %1 i %2",
     "DATA_SHOWLIST": "taispeáin liosta %1",
     "DATA_HIDELIST": "folaigh liosta %1",
-    "SENSING_OF_XPOSITION": "ionad x",
-    "SENSING_OF_YPOSITION": "ionad y",
-    "SENSING_OF_DIRECTION": "treo",
+    "MOTION_XPOSITION": "ionad x",
+    "MOTION_YPOSITION": "ionad y",
+    "MOTION_DIRECTION": "treo",
     "SENSING_OF_COSTUMENUMBER": "culaith #",
     "LOOKS_COSTUMENUMBERNAME": "culaith %1",
-    "SENSING_OF_SIZE": "méid",
+    "LOOKS_SIZE": "méid",
     "SENSING_OF_BACKDROPNAME": "ainm an chúlra",
     "LOOKS_BACKDROPNUMBERNAME": "cúlra %1",
     "SENSING_OF_BACKDROPNUMBER": "cúlra #",
@@ -256,6 +256,5 @@
     "10 ^"
   ],
   "aliases": {},
-  "name": "Gaeilge",
-  "percentTranslated": 100
+  "name": "Gaeilge"
 }

--- a/locales/gd.json
+++ b/locales/gd.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "falaich",
     "LOOKS_SWITCHCOSTUMETO": "cuir dreach %1 ort",
     "LOOKS_NEXTCOSTUME": "an t-ath-dhreach",
-    "LOOKS_NEXTBACKDROP_BLOCK": "an t-ath-chùlaibh",
+    "LOOKS_NEXTBACKDROP": "an t-ath-chùlaibh",
     "LOOKS_SWITCHBACKDROPTO": "cuir %1 air a’ chùlaibh",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "cuir %1 air a’ chùlaibh is fan ri càch",
     "LOOKS_CHANGEEFFECTBY": "atharraich èifeachd %1 le %2",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "cuir %3 an àite nì %1 de %2",
     "DATA_SHOWLIST": "seall an liosta %1",
     "DATA_HIDELIST": "falaich an liosta %1",
-    "SENSING_OF_XPOSITION": "ionad x",
-    "SENSING_OF_YPOSITION": "ionad y",
-    "SENSING_OF_DIRECTION": "comhair",
+    "MOTION_XPOSITION": "ionad x",
+    "MOTION_YPOSITION": "ionad y",
+    "MOTION_DIRECTION": "comhair",
     "SENSING_OF_COSTUMENUMBER": "àireamh an dreacha",
     "LOOKS_COSTUMENUMBERNAME": "%1 an dreacha",
-    "SENSING_OF_SIZE": "meud",
+    "LOOKS_SIZE": "meud",
     "SENSING_OF_BACKDROPNAME": "ainm a’ chùlaibh",
     "LOOKS_BACKDROPNUMBERNAME": "%1 a’ chùlaibh",
     "SENSING_OF_BACKDROPNUMBER": "àireamh a’ chùlaibh",
@@ -261,6 +261,5 @@
     "le briogadh air @greenFlag": "EVENT_WHENFLAGCLICKED",
     "deireadh": "scratchblocks:end"
   },
-  "name": "Gàidhlig",
-  "percentTranslated": 100
+  "name": "Gàidhlig"
 }

--- a/locales/gl.json
+++ b/locales/gl.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "agocharse",
     "LOOKS_SWITCHCOSTUMETO": "mudar traxe a %1",
     "LOOKS_NEXTCOSTUME": "traxe seguinte",
-    "LOOKS_NEXTBACKDROP_BLOCK": "fondo seguinte",
+    "LOOKS_NEXTBACKDROP": "fondo seguinte",
     "LOOKS_SWITCHBACKDROPTO": "mudar fondo a %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "mudar fondo a %1 e agardar",
     "LOOKS_CHANGEEFFECTBY": "sumar %2 ao efecto %1",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "substituír o elemento %1 de %2 por %3",
     "DATA_SHOWLIST": "amosar a lista %1",
     "DATA_HIDELIST": "agochar a lista %1",
-    "SENSING_OF_XPOSITION": "posición en X",
-    "SENSING_OF_YPOSITION": "posición en Y",
-    "SENSING_OF_DIRECTION": "dirección",
+    "MOTION_XPOSITION": "posición en X",
+    "MOTION_YPOSITION": "posición en Y",
+    "MOTION_DIRECTION": "dirección",
     "SENSING_OF_COSTUMENUMBER": "traxe n.º",
     "LOOKS_COSTUMENUMBERNAME": "traxe %1",
-    "SENSING_OF_SIZE": "tamaño",
+    "LOOKS_SIZE": "tamaño",
     "SENSING_OF_BACKDROPNAME": "nome do fondo",
     "LOOKS_BACKDROPNUMBERNAME": "fondo %1",
     "SENSING_OF_BACKDROPNUMBER": "fondo n.º",
@@ -256,6 +256,5 @@
     "10 ^"
   ],
   "aliases": {},
-  "name": "Galego",
-  "percentTranslated": 100
+  "name": "Galego"
 }

--- a/locales/ha.json
+++ b/locales/ha.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "ɓoye",
     "LOOKS_SWITCHCOSTUMETO": "sauya fasalin zuwa %1",
     "LOOKS_NEXTCOSTUME": "fasali na gaba",
-    "LOOKS_NEXTBACKDROP_BLOCK": "hoton fage na gaba",
+    "LOOKS_NEXTBACKDROP": "hoton fage na gaba",
     "LOOKS_SWITCHBACKDROPTO": "sauya hoton fage zuwa %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "sauya hoton fage zuwa %1 kuma a jira",
     "LOOKS_CHANGEEFFECTBY": "canza tsarin %1 zuwa %2",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "mayar da abun %1 na %2 da %3",
     "DATA_SHOWLIST": "nuna jerin %1",
     "DATA_HIDELIST": "ɓoye jerin %1",
-    "SENSING_OF_XPOSITION": "matsayin x",
-    "SENSING_OF_YPOSITION": "matsayin y",
-    "SENSING_OF_DIRECTION": "mafuskanta",
+    "MOTION_XPOSITION": "matsayin x",
+    "MOTION_YPOSITION": "matsayin y",
+    "MOTION_DIRECTION": "mafuskanta",
     "SENSING_OF_COSTUMENUMBER": "fasali #",
     "LOOKS_COSTUMENUMBERNAME": "fasalin %1",
-    "SENSING_OF_SIZE": "girma",
+    "LOOKS_SIZE": "girma",
     "SENSING_OF_BACKDROPNAME": "sunan hoton fage",
     "LOOKS_BACKDROPNUMBERNAME": "hoton fagen %1",
     "SENSING_OF_BACKDROPNUMBER": "hoton fage",
@@ -256,6 +256,5 @@
     "10 ^"
   ],
   "aliases": {},
-  "name": "Hausa",
-  "percentTranslated": 100
+  "name": "Hausa"
 }

--- a/locales/he.json
+++ b/locales/he.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "הסתר",
     "LOOKS_SWITCHCOSTUMETO": "קבע תלבושת ל %1",
     "LOOKS_NEXTCOSTUME": "התלבושת הבאה",
-    "LOOKS_NEXTBACKDROP_BLOCK": "הרקע הבא",
+    "LOOKS_NEXTBACKDROP": "הרקע הבא",
     "LOOKS_SWITCHBACKDROPTO": "קבע רקע ל %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "החלף רקע ל %1 וחכה",
     "LOOKS_CHANGEEFFECTBY": "שנה אפקט %1 ב %2",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "קבע פריט %1 של %2 ל %3",
     "DATA_SHOWLIST": "הצג רשימה %1",
     "DATA_HIDELIST": "הסתר רשימה %1",
-    "SENSING_OF_XPOSITION": "מיקום על ציר x",
-    "SENSING_OF_YPOSITION": "מיקום על ציר y",
-    "SENSING_OF_DIRECTION": "כיוון",
+    "MOTION_XPOSITION": "מיקום על ציר x",
+    "MOTION_YPOSITION": "מיקום על ציר y",
+    "MOTION_DIRECTION": "כיוון",
     "SENSING_OF_COSTUMENUMBER": "מספר תלבושת",
     "LOOKS_COSTUMENUMBERNAME": "%1 תלבושת",
-    "SENSING_OF_SIZE": "גודל",
+    "LOOKS_SIZE": "גודל",
     "SENSING_OF_BACKDROPNAME": "שם רקע",
     "LOOKS_BACKDROPNUMBERNAME": "%1 רקע",
     "SENSING_OF_BACKDROPNUMBER": "מספר רקע",
@@ -261,6 +261,5 @@
     "כאשר לוחצים על דגל ירוק": "EVENT_WHENFLAGCLICKED",
     "סוף": "scratchblocks:end"
   },
-  "name": "עִבְרִית",
-  "percentTranslated": 100
+  "name": "עִבְרִית"
 }

--- a/locales/hi.json
+++ b/locales/hi.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "छुपाएँ",
     "LOOKS_SWITCHCOSTUMETO": "%1 से पोशाख बदले",
     "LOOKS_NEXTCOSTUME": "अगली पोशाक",
-    "LOOKS_NEXTBACKDROP_BLOCK": "अगली पृष्ठभूमि",
+    "LOOKS_NEXTBACKDROP": "अगली पृष्ठभूमि",
     "LOOKS_SWITCHBACKDROPTO": "%1 से पृष्ठभूमि बदले",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "पृष्ठभूमि को %1 से बदले और रुके",
     "LOOKS_CHANGEEFFECTBY": "बदले %1 प्रभाव को %2 से",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "%2 की %1 चीज बदले %3 से",
     "DATA_SHOWLIST": "%1 सूचि दिखाएँ",
     "DATA_HIDELIST": "%1 सूचि छुपाए",
-    "SENSING_OF_XPOSITION": "x स्थिति",
-    "SENSING_OF_YPOSITION": "y स्थिति",
-    "SENSING_OF_DIRECTION": "दिशा",
+    "MOTION_XPOSITION": "x स्थिति",
+    "MOTION_YPOSITION": "y स्थिति",
+    "MOTION_DIRECTION": "दिशा",
     "SENSING_OF_COSTUMENUMBER": "पोशाक #",
     "LOOKS_COSTUMENUMBERNAME": "%1 पोषाख",
-    "SENSING_OF_SIZE": "आकार",
+    "LOOKS_SIZE": "आकार",
     "SENSING_OF_BACKDROPNAME": "पृष्ठभूमि का नाम",
     "LOOKS_BACKDROPNUMBERNAME": "%1 पृष्ठभूमि",
     "SENSING_OF_BACKDROPNUMBER": "पृष्ठभूमि#",
@@ -261,6 +261,5 @@
     "जब झंडे को क्लिक किया गया हो": "EVENT_WHENFLAGCLICKED",
     "अंत": "scratchblocks:end"
   },
-  "name": "हिंदी",
-  "percentTranslated": 100
+  "name": "हिंदी"
 }

--- a/locales/hr.json
+++ b/locales/hr.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "sakrij",
     "LOOKS_SWITCHCOSTUMETO": "promijeni kostim u %1",
     "LOOKS_NEXTCOSTUME": "sljedeći kostim",
-    "LOOKS_NEXTBACKDROP_BLOCK": "sljedeća pozadina",
+    "LOOKS_NEXTBACKDROP": "sljedeća pozadina",
     "LOOKS_SWITCHBACKDROPTO": "promijeni pozadinu na %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "promijeni pozadinu u %1 i čekaj",
     "LOOKS_CHANGEEFFECTBY": "promijeni efekt %1 za %2",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "zamijeni %1 na %2 s %3",
     "DATA_SHOWLIST": "prikaži listu %1",
     "DATA_HIDELIST": "sakrij listu %1",
-    "SENSING_OF_XPOSITION": "x položaj",
-    "SENSING_OF_YPOSITION": "y položaj",
-    "SENSING_OF_DIRECTION": "smjer",
+    "MOTION_XPOSITION": "x položaj",
+    "MOTION_YPOSITION": "y položaj",
+    "MOTION_DIRECTION": "smjer",
     "SENSING_OF_COSTUMENUMBER": "kostim #",
     "LOOKS_COSTUMENUMBERNAME": "kostim %1",
-    "SENSING_OF_SIZE": "veličina",
+    "LOOKS_SIZE": "veličina",
     "SENSING_OF_BACKDROPNAME": "naziv pozadine",
     "LOOKS_BACKDROPNUMBERNAME": "pozadina %1",
     "SENSING_OF_BACKDROPNUMBER": "pozadina #",
@@ -261,6 +261,5 @@
     "kada je zelena zastava kliknut": "EVENT_WHENFLAGCLICKED",
     "kraj": "scratchblocks:end"
   },
-  "name": "Hrvatski",
-  "percentTranslated": 100
+  "name": "Hrvatski"
 }

--- a/locales/ht.json
+++ b/locales/ht.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "kache",
     "LOOKS_SWITCHCOSTUMETO": "chanje a kostim %1",
     "LOOKS_NEXTCOSTUME": "pwochenn kostim",
-    "LOOKS_NEXTBACKDROP_BLOCK": "pwochenn fon",
+    "LOOKS_NEXTBACKDROP": "pwochenn fon",
     "LOOKS_SWITCHBACKDROPTO": "chanje fon an a %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "chanje fon a %1 epi tann",
     "LOOKS_CHANGEEFFECTBY": "chanje efè %1 pa %2",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "ranplase %1 nan %2 avèk %3",
     "DATA_SHOWLIST": "montre lis %1",
     "DATA_HIDELIST": "kache lis %1",
-    "SENSING_OF_XPOSITION": "pozisyon x",
-    "SENSING_OF_YPOSITION": "pozisyon y",
-    "SENSING_OF_DIRECTION": "direksyon",
+    "MOTION_XPOSITION": "pozisyon x",
+    "MOTION_YPOSITION": "pozisyon y",
+    "MOTION_DIRECTION": "direksyon",
     "SENSING_OF_COSTUMENUMBER": "kostim #",
     "LOOKS_COSTUMENUMBERNAME": "kostim %1",
-    "SENSING_OF_SIZE": "gwosè",
+    "LOOKS_SIZE": "gwosè",
     "SENSING_OF_BACKDROPNAME": "non fon an",
     "LOOKS_BACKDROPNUMBERNAME": "fon %1",
     "SENSING_OF_BACKDROPNUMBER": "# fon",
@@ -256,6 +256,5 @@
     "10 ^"
   ],
   "aliases": {},
-  "name": "Kreyòl ayisyen",
-  "percentTranslated": 100
+  "name": "Kreyòl ayisyen"
 }

--- a/locales/hu.json
+++ b/locales/hu.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "tűnj el",
     "LOOKS_SWITCHCOSTUMETO": "jelmez legyen %1",
     "LOOKS_NEXTCOSTUME": "következő jelmez",
-    "LOOKS_NEXTBACKDROP_BLOCK": "következő háttér",
+    "LOOKS_NEXTBACKDROP": "következő háttér",
     "LOOKS_SWITCHBACKDROPTO": "háttér legyen %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "háttér legyen %1 és várj",
     "LOOKS_CHANGEEFFECTBY": "%1 hatás változzon %2",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "cseréld le %1 elemet %2 listában %3 elemre",
     "DATA_SHOWLIST": "%1 lista jelenjen meg",
     "DATA_HIDELIST": "%1 lista tűnjön el",
-    "SENSING_OF_XPOSITION": "x hely",
-    "SENSING_OF_YPOSITION": "y hely",
-    "SENSING_OF_DIRECTION": "irány",
+    "MOTION_XPOSITION": "x hely",
+    "MOTION_YPOSITION": "y hely",
+    "MOTION_DIRECTION": "irány",
     "SENSING_OF_COSTUMENUMBER": "jelmez sorszáma",
     "LOOKS_COSTUMENUMBERNAME": "jelmez %1",
-    "SENSING_OF_SIZE": "mérete",
+    "LOOKS_SIZE": "méret",
     "SENSING_OF_BACKDROPNAME": "háttér neve",
     "LOOKS_BACKDROPNUMBERNAME": "háttér %1",
     "SENSING_OF_BACKDROPNUMBER": "háttér sorszáma",
@@ -262,6 +262,5 @@
     "a zászlóra kattintáskor": "EVENT_WHENFLAGCLICKED",
     "vége": "scratchblocks:end"
   },
-  "name": "Magyar",
-  "percentTranslated": 100
+  "name": "Magyar"
 }

--- a/locales/hy.json
+++ b/locales/hy.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "թաքցնել",
     "LOOKS_SWITCHCOSTUMETO": "զգեստը՝ %1",
     "LOOKS_NEXTCOSTUME": "հաջորդ զգեստը",
-    "LOOKS_NEXTBACKDROP_BLOCK": "հաջորդ ետնապատկերը",
+    "LOOKS_NEXTBACKDROP": "հաջորդ ետնապատկերը",
     "LOOKS_SWITCHBACKDROPTO": "ետնապատկերը՝ %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "Ետնապատկերը փոխարինել %1 -ով և սպասել",
     "LOOKS_CHANGEEFFECTBY": "փոխել %1 էֆՖեկտը %2 -ով",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "փոխարինել %1 տարրը %2-ից  %3-ով",
     "DATA_SHOWLIST": "ցույց տալ %1 ցուցակը",
     "DATA_HIDELIST": "թաքցնել %1 ցուցակը",
-    "SENSING_OF_XPOSITION": "x -ը",
-    "SENSING_OF_YPOSITION": "y -ը",
-    "SENSING_OF_DIRECTION": "ուղղություն",
+    "MOTION_XPOSITION": "x -ը",
+    "MOTION_YPOSITION": "y -ը",
+    "MOTION_DIRECTION": "ուղղություն",
     "SENSING_OF_COSTUMENUMBER": "զգեստ #",
     "LOOKS_COSTUMENUMBERNAME": "զգեստ %1",
-    "SENSING_OF_SIZE": "չափս",
+    "LOOKS_SIZE": "չափս",
     "SENSING_OF_BACKDROPNAME": "ետնապատկերի անունը",
     "LOOKS_BACKDROPNUMBERNAME": "ետնապատկեր %1",
     "SENSING_OF_BACKDROPNUMBER": "ետնապատկեր #",
@@ -256,6 +256,5 @@
     "10 ^"
   ],
   "aliases": {},
-  "name": "Հայերեն",
-  "percentTranslated": 100
+  "name": "Հայերեն"
 }

--- a/locales/id.json
+++ b/locales/id.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "sembunyikan",
     "LOOKS_SWITCHCOSTUMETO": "ganti kostum ke %1",
     "LOOKS_NEXTCOSTUME": "kostum berikutnya",
-    "LOOKS_NEXTBACKDROP_BLOCK": "latar berikutnya",
+    "LOOKS_NEXTBACKDROP": "latar berikutnya",
     "LOOKS_SWITCHBACKDROPTO": "ganti latar ke %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "ganti latar ke %1 dan tunggu",
     "LOOKS_CHANGEEFFECTBY": "ubah efek %1 sebesar %2",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "ganti benda %1 dari %2 dengan %3",
     "DATA_SHOWLIST": "tampilkan daftar %1",
     "DATA_HIDELIST": "sembunyikan daftar %1",
-    "SENSING_OF_XPOSITION": "posisi x",
-    "SENSING_OF_YPOSITION": "posisi y",
-    "SENSING_OF_DIRECTION": "arah",
+    "MOTION_XPOSITION": "posisi x",
+    "MOTION_YPOSITION": "posisi y",
+    "MOTION_DIRECTION": "arah",
     "SENSING_OF_COSTUMENUMBER": "# kostum",
     "LOOKS_COSTUMENUMBERNAME": "%1 kostum",
-    "SENSING_OF_SIZE": "ukuran",
+    "LOOKS_SIZE": "ukuran",
     "SENSING_OF_BACKDROPNAME": "nama latar",
     "LOOKS_BACKDROPNUMBERNAME": "latar %1",
     "SENSING_OF_BACKDROPNUMBER": "latar #",
@@ -261,6 +261,5 @@
     "ketika bendera hijau diklik": "EVENT_WHENFLAGCLICKED",
     "selesai": "scratchblocks:end"
   },
-  "name": "Bahasa Indonesia",
-  "percentTranslated": 100
+  "name": "Bahasa Indonesia"
 }

--- a/locales/is.json
+++ b/locales/is.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "fela",
     "LOOKS_SWITCHCOSTUMETO": "breyttu í búning %1",
     "LOOKS_NEXTCOSTUME": "næsti búningur",
-    "LOOKS_NEXTBACKDROP_BLOCK": "næsti bakgrunnur",
+    "LOOKS_NEXTBACKDROP": "næsti bakgrunnur",
     "LOOKS_SWITCHBACKDROPTO": "bakgrunnur verður %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "nota bakgrunn %1 og bíða",
     "LOOKS_CHANGEEFFECTBY": "breyta %1 áhrifunum um %2",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "skiptu út hlut %1 af %2 fyrir %3",
     "DATA_SHOWLIST": "sýndu lista %1",
     "DATA_HIDELIST": "feldu lista %1",
-    "SENSING_OF_XPOSITION": "x hnit",
-    "SENSING_OF_YPOSITION": "y hnit",
-    "SENSING_OF_DIRECTION": "stefna",
+    "MOTION_XPOSITION": "x hnit",
+    "MOTION_YPOSITION": "y hnit",
+    "MOTION_DIRECTION": "stefna",
     "SENSING_OF_COSTUMENUMBER": "búnungur númer",
     "LOOKS_COSTUMENUMBERNAME": "búningur %1",
-    "SENSING_OF_SIZE": "stærð",
+    "LOOKS_SIZE": "stærð",
     "SENSING_OF_BACKDROPNAME": "nafn bakgrunns",
     "LOOKS_BACKDROPNUMBERNAME": "bakgrunnur %1",
     "SENSING_OF_BACKDROPNUMBER": "bakgrunnur númer",
@@ -256,6 +256,5 @@
     "10 ^"
   ],
   "aliases": {},
-  "name": "Íslenska",
-  "percentTranslated": 100
+  "name": "Íslenska"
 }

--- a/locales/it.json
+++ b/locales/it.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "nascondi",
     "LOOKS_SWITCHCOSTUMETO": "passa al costume %1",
     "LOOKS_NEXTCOSTUME": "passa al costume seguente",
-    "LOOKS_NEXTBACKDROP_BLOCK": "passa allo sfondo seguente",
+    "LOOKS_NEXTBACKDROP": "seguente",
     "LOOKS_SWITCHBACKDROPTO": "passa allo sfondo %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "passa allo sfondo %1 e attendi",
     "LOOKS_CHANGEEFFECTBY": "cambia effetto %1 di %2",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "sostituisci elemento %1 di %2 con %3",
     "DATA_SHOWLIST": "mostra la lista %1",
     "DATA_HIDELIST": "nascondi la lista %1",
-    "SENSING_OF_XPOSITION": "posizione x",
-    "SENSING_OF_YPOSITION": "posizione y",
-    "SENSING_OF_DIRECTION": "direzione",
+    "MOTION_XPOSITION": "posizione x",
+    "MOTION_YPOSITION": "posizione y",
+    "MOTION_DIRECTION": "direzione",
     "SENSING_OF_COSTUMENUMBER": "numero del costume",
     "LOOKS_COSTUMENUMBERNAME": "%1 costume",
-    "SENSING_OF_SIZE": "dimensione",
+    "LOOKS_SIZE": "dimensione",
     "SENSING_OF_BACKDROPNAME": "nome dello sfondo",
     "LOOKS_BACKDROPNUMBERNAME": "%1 sfondo",
     "SENSING_OF_BACKDROPNUMBER": "numero dello sfondo",
@@ -261,6 +261,5 @@
     "quando si clicca sulla bandiera verde": "EVENT_WHENFLAGCLICKED",
     "fine": "scratchblocks:end"
   },
-  "name": "Italiano",
-  "percentTranslated": 100
+  "name": "Italiano"
 }

--- a/locales/ja-Hira.json
+++ b/locales/ja-Hira.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "かくす",
     "LOOKS_SWITCHCOSTUMETO": "コスチュームを %1 にする",
     "LOOKS_NEXTCOSTUME": "つぎのコスチュームにする",
-    "LOOKS_NEXTBACKDROP_BLOCK": "つぎのはいけいにする",
+    "LOOKS_NEXTBACKDROP": "つぎのはいけい",
     "LOOKS_SWITCHBACKDROPTO": "はいけいを %1 にする",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "はいけいを %1 にしてまつ",
     "LOOKS_CHANGEEFFECTBY": "%1 のこうかを %2 ずつかえる",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "%2 の %1 ばんめを %3 でおきかえる",
     "DATA_SHOWLIST": "リスト %1 をひょうじする",
     "DATA_HIDELIST": "リスト %1 をかくす",
-    "SENSING_OF_XPOSITION": "xざひょう",
-    "SENSING_OF_YPOSITION": "yざひょう",
-    "SENSING_OF_DIRECTION": "むき",
+    "MOTION_XPOSITION": "xざひょう",
+    "MOTION_YPOSITION": "yざひょう",
+    "MOTION_DIRECTION": "むき",
     "SENSING_OF_COSTUMENUMBER": "コスチューム #",
     "LOOKS_COSTUMENUMBERNAME": "コスチュームの %1",
-    "SENSING_OF_SIZE": "おおきさ",
+    "LOOKS_SIZE": "おおきさ",
     "SENSING_OF_BACKDROPNAME": "はいけいのなまえ",
     "LOOKS_BACKDROPNUMBERNAME": "はいけいの %1",
     "SENSING_OF_BACKDROPNUMBER": "はいけい #",
@@ -263,6 +263,5 @@
     "みどりのはたがおされたとき": "EVENT_WHENFLAGCLICKED",
     "みどりのはたがクリックされたとき": "EVENT_WHENFLAGCLICKED"
   },
-  "name": "にほんご",
-  "percentTranslated": 100
+  "name": "にほんご"
 }

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "隠す",
     "LOOKS_SWITCHCOSTUMETO": "コスチュームを %1 にする",
     "LOOKS_NEXTCOSTUME": "次のコスチュームにする",
-    "LOOKS_NEXTBACKDROP_BLOCK": "次の背景にする",
+    "LOOKS_NEXTBACKDROP": "次の背景",
     "LOOKS_SWITCHBACKDROPTO": "背景を %1 にする",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "背景を %1 にして待つ",
     "LOOKS_CHANGEEFFECTBY": "%1 の効果を %2 ずつ変える",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "%2 の %1 番目を %3 で置き換える",
     "DATA_SHOWLIST": "リスト %1 を表示する",
     "DATA_HIDELIST": "リスト %1 を隠す",
-    "SENSING_OF_XPOSITION": "x座標",
-    "SENSING_OF_YPOSITION": "y座標",
-    "SENSING_OF_DIRECTION": "向き",
+    "MOTION_XPOSITION": "x座標",
+    "MOTION_YPOSITION": "y座標",
+    "MOTION_DIRECTION": "向き",
     "SENSING_OF_COSTUMENUMBER": "コスチューム #",
     "LOOKS_COSTUMENUMBERNAME": "コスチュームの %1",
-    "SENSING_OF_SIZE": "大きさ",
+    "LOOKS_SIZE": "大きさ",
     "SENSING_OF_BACKDROPNAME": "背景の名前",
     "LOOKS_BACKDROPNUMBERNAME": "背景の %1",
     "SENSING_OF_BACKDROPNUMBER": "背景 #",
@@ -263,6 +263,5 @@
     "緑の旗が押されたとき": "EVENT_WHENFLAGCLICKED",
     "緑の旗がクリックされたとき": "EVENT_WHENFLAGCLICKED"
   },
-  "name": "日本語",
-  "percentTranslated": 100
+  "name": "日本語"
 }

--- a/locales/ka.json
+++ b/locales/ka.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "დაიმალე",
     "LOOKS_SWITCHCOSTUMETO": "გადაერთე კოსტიუმზე %1",
     "LOOKS_NEXTCOSTUME": "მომდევნო კოსტიუმი",
-    "LOOKS_NEXTBACKDROP_BLOCK": "მომდევნო ფონი",
+    "LOOKS_NEXTBACKDROP": "მომდევნო ფონი",
     "LOOKS_SWITCHBACKDROPTO": "გადაერთე ფონზე %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "გადაერთე ფონზე %1 და იცადე",
     "LOOKS_CHANGEEFFECTBY": "შეცვალე%1ეფექტი%2ით",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "შეცვალე %1 %2დან %3ით",
     "DATA_SHOWLIST": "გამოაჩინე სია %1",
     "DATA_HIDELIST": "დამალე სია %1",
-    "SENSING_OF_XPOSITION": "x მდებარეობა",
-    "SENSING_OF_YPOSITION": "y მდებარეობა",
-    "SENSING_OF_DIRECTION": "მიმართულება",
+    "MOTION_XPOSITION": "x მდებარეობა",
+    "MOTION_YPOSITION": "y მდებარეობა",
+    "MOTION_DIRECTION": "მიმართულება",
     "SENSING_OF_COSTUMENUMBER": "კოსტიუმის ნომერი",
     "LOOKS_COSTUMENUMBERNAME": "კოსტიუმი %1",
-    "SENSING_OF_SIZE": "ზომა",
+    "LOOKS_SIZE": "ზომა",
     "SENSING_OF_BACKDROPNAME": "ფონის სახელი",
     "LOOKS_BACKDROPNUMBERNAME": "ფონი %1",
     "SENSING_OF_BACKDROPNUMBER": "ფონის ნომერი",
@@ -256,6 +256,5 @@
     "10^"
   ],
   "aliases": {},
-  "name": "ქართული ენა",
-  "percentTranslated": 100
+  "name": "ქართული ენა"
 }

--- a/locales/kk.json
+++ b/locales/kk.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "жасыру",
     "LOOKS_SWITCHCOSTUMETO": "киімін %1ге ауыстыру",
     "LOOKS_NEXTCOSTUME": "келесі костюм",
-    "LOOKS_NEXTBACKDROP_BLOCK": "келесі фон",
+    "LOOKS_NEXTBACKDROP": "келесі фон",
     "LOOKS_SWITCHBACKDROPTO": "аясын %1ге ауыстыру",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "аясын %1ге ауыстырып күту",
     "LOOKS_CHANGEEFFECTBY": "%1 әсерін %2ге өзерту",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "%2нің %1ін %3пен алмастыру",
     "DATA_SHOWLIST": "%1 тізімін көрсет",
     "DATA_HIDELIST": "%1 тізімін жасыр",
-    "SENSING_OF_XPOSITION": "x орны",
-    "SENSING_OF_YPOSITION": "y орны",
-    "SENSING_OF_DIRECTION": "бағыт",
+    "MOTION_XPOSITION": "x орны",
+    "MOTION_YPOSITION": "y орны",
+    "MOTION_DIRECTION": "бағыт",
     "SENSING_OF_COSTUMENUMBER": "костюм #",
     "LOOKS_COSTUMENUMBERNAME": "%1 киімі",
-    "SENSING_OF_SIZE": "өлшем",
+    "LOOKS_SIZE": "өлшем",
     "SENSING_OF_BACKDROPNAME": "фонның аты",
     "LOOKS_BACKDROPNUMBERNAME": "%1 аясы",
     "SENSING_OF_BACKDROPNUMBER": "фон #",
@@ -258,6 +258,5 @@
     "10 ^"
   ],
   "aliases": {},
-  "name": "қазақша",
-  "percentTranslated": 100
+  "name": "қазақша"
 }

--- a/locales/km.json
+++ b/locales/km.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "លាក់",
     "LOOKS_SWITCHCOSTUMETO": "ប្តូររូបរាងទៅជា %1",
     "LOOKS_NEXTCOSTUME": "រូបរាងបន្ទាប់",
-    "LOOKS_NEXTBACKDROP_BLOCK": "ផ្ទាំងខាងក្រោយបន្ទាប់",
+    "LOOKS_NEXTBACKDROP": "ផ្ទាំងខាងក្រោយបន្ទាប់",
     "LOOKS_SWITCHBACKDROPTO": "ប្ដូរផ្ទាំង​ខាងក្រោយ​ទៅជា %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "ប្ដូរផ្ទាំងខាង​ក្រោយ​ទៅជា %1 ហើយ​រងចាំ",
     "LOOKS_CHANGEEFFECTBY": "ប្តូរបែបផែន %1 ចំនួន %2",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "ជំនួសធាតុ %1 នៃ %2 ដោយ %3",
     "DATA_SHOWLIST": "បង្ហាញបញ្ជី %1",
     "DATA_HIDELIST": "លាក់បញ្ជី %1",
-    "SENSING_OF_XPOSITION": "ទីតាំង x",
-    "SENSING_OF_YPOSITION": "ទីតាំង y",
-    "SENSING_OF_DIRECTION": "ទិសដៅ",
+    "MOTION_XPOSITION": "ទីតាំង x",
+    "MOTION_YPOSITION": "ទីតាំង y",
+    "MOTION_DIRECTION": "ទិសដៅ",
     "SENSING_OF_COSTUMENUMBER": "រូបរាង #",
     "LOOKS_COSTUMENUMBERNAME": "រូបរាង %1",
-    "SENSING_OF_SIZE": "ទំហំ",
+    "LOOKS_SIZE": "ទំហំ",
     "SENSING_OF_BACKDROPNAME": "ឈ្មោះផ្ទាំងខាងក្រោយ",
     "LOOKS_BACKDROPNUMBERNAME": "ផ្ទាំងខាងក្រោយ %1",
     "SENSING_OF_BACKDROPNUMBER": "ផ្ទាំងខាងក្រោយ #",
@@ -256,6 +256,5 @@
     "10 ^"
   ],
   "aliases": {},
-  "name": "ភាសាខ្មែរ",
-  "percentTranslated": 100
+  "name": "ភាសាខ្មែរ"
 }

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "숨기기",
     "LOOKS_SWITCHCOSTUMETO": "모양을 %1 (으)로 바꾸기",
     "LOOKS_NEXTCOSTUME": "다음 모양으로 바꾸기",
-    "LOOKS_NEXTBACKDROP_BLOCK": "다음 배경으로 바꾸기",
+    "LOOKS_NEXTBACKDROP": "다음 배경",
     "LOOKS_SWITCHBACKDROPTO": "배경을 %1 (으)로 바꾸기",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "배경을 %1 (으)로 바꾸고 기다리기",
     "LOOKS_CHANGEEFFECTBY": "%1 효과를 %2 만큼 바꾸기",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "%2 리스트의 %1 번째 항목을 %3 으로 바꾸기",
     "DATA_SHOWLIST": "%1 리스트 보이기",
     "DATA_HIDELIST": "%1 리스트 숨기기",
-    "SENSING_OF_XPOSITION": "x좌표",
-    "SENSING_OF_YPOSITION": "y좌표",
-    "SENSING_OF_DIRECTION": "방향",
+    "MOTION_XPOSITION": "x좌표",
+    "MOTION_YPOSITION": "y좌표",
+    "MOTION_DIRECTION": "방향",
     "SENSING_OF_COSTUMENUMBER": "모양 번호",
     "LOOKS_COSTUMENUMBERNAME": "모양 %1",
-    "SENSING_OF_SIZE": "크기",
+    "LOOKS_SIZE": "크기",
     "SENSING_OF_BACKDROPNAME": "배경 이름",
     "LOOKS_BACKDROPNUMBERNAME": "배경 %1",
     "SENSING_OF_BACKDROPNUMBER": "배경 번호",
@@ -256,6 +256,5 @@
     "10 ^"
   ],
   "aliases": {},
-  "name": "한국어",
-  "percentTranslated": 100
+  "name": "한국어"
 }

--- a/locales/ku.json
+++ b/locales/ku.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "veşêre",
     "LOOKS_SWITCHCOSTUMETO": "kostumê %1ê li xwe bike",
     "LOOKS_NEXTCOSTUME": "kostumê pêş",
-    "LOOKS_NEXTBACKDROP_BLOCK": "dekora piştre",
+    "LOOKS_NEXTBACKDROP": "dekora piştre",
     "LOOKS_SWITCHBACKDROPTO": "derbasî dekora %1ê bibe",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "derbasî dekora %1 bibe û bisekine",
     "LOOKS_CHANGEEFFECTBY": "efekta %1 bi qasî %2 biguherîne",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "hêmana %2 ya %1ê bi %3ê re pev biguherîne",
     "DATA_SHOWLIST": "lîsteya %1ê nîşan bide",
     "DATA_HIDELIST": "lîsteya %1ê veşêre",
-    "SENSING_OF_XPOSITION": "cîgeha x'ê",
-    "SENSING_OF_YPOSITION": "cîgeha y'yê",
-    "SENSING_OF_DIRECTION": "hêl",
+    "MOTION_XPOSITION": "cîgeha x'ê",
+    "MOTION_YPOSITION": "cîgeha y'yê",
+    "MOTION_DIRECTION": "hêl",
     "SENSING_OF_COSTUMENUMBER": "kostum #",
     "LOOKS_COSTUMENUMBERNAME": "kostumê %1",
-    "SENSING_OF_SIZE": "mezinahî",
+    "LOOKS_SIZE": "mezinahî",
     "SENSING_OF_BACKDROPNAME": "navê dekorê",
     "LOOKS_BACKDROPNUMBERNAME": "dekora %1",
     "SENSING_OF_BACKDROPNUMBER": "dekor #",
@@ -258,6 +258,5 @@
     "10 ^"
   ],
   "aliases": {},
-  "name": "Kurdî",
-  "percentTranslated": 100
+  "name": "Kurdî"
 }

--- a/locales/lt.json
+++ b/locales/lt.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "slėpk",
     "LOOKS_SWITCHCOSTUMETO": "kaukė = %1",
     "LOOKS_NEXTCOSTUME": "kita kaukė",
-    "LOOKS_NEXTBACKDROP_BLOCK": "kitas  fonas",
+    "LOOKS_NEXTBACKDROP": "kitas  fonas",
     "LOOKS_SWITCHBACKDROPTO": "fonas = %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "fonas = %1 (palauk, kol pasikeis)",
     "LOOKS_CHANGEEFFECTBY": "efektą %1 padidink %2",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "sąrašo %2  %1 vietai priskirti %3",
     "DATA_SHOWLIST": "rodyti sąrašą %1",
     "DATA_HIDELIST": "slėpti sąrašą %1",
-    "SENSING_OF_XPOSITION": "x koordinatė",
-    "SENSING_OF_YPOSITION": "y koordinatė",
-    "SENSING_OF_DIRECTION": "kryptis",
+    "MOTION_XPOSITION": "x vieta",
+    "MOTION_YPOSITION": "y vieta",
+    "MOTION_DIRECTION": "kryptis",
     "SENSING_OF_COSTUMENUMBER": "kaukės nr.",
     "LOOKS_COSTUMENUMBERNAME": "kaukė %1",
-    "SENSING_OF_SIZE": "dydis",
+    "LOOKS_SIZE": "dydis",
     "SENSING_OF_BACKDROPNAME": "fono pavadinimas",
     "LOOKS_BACKDROPNUMBERNAME": "fonas %1",
     "SENSING_OF_BACKDROPNUMBER": "fono nr.",
@@ -256,6 +256,5 @@
     "10 ^"
   ],
   "aliases": {},
-  "name": "Lietuvių",
-  "percentTranslated": 100
+  "name": "Lietuvių"
 }

--- a/locales/lv.json
+++ b/locales/lv.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "slēpt",
     "LOOKS_SWITCHCOSTUMETO": "mainīt tērpu uz %1",
     "LOOKS_NEXTCOSTUME": "nākamais tērps",
-    "LOOKS_NEXTBACKDROP_BLOCK": "nākamais fons",
+    "LOOKS_NEXTBACKDROP": "nākamais fons",
     "LOOKS_SWITCHBACKDROPTO": "mainīt fonu uz %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "mainīt fonu uz %1 un gaidīt",
     "LOOKS_CHANGEEFFECTBY": "mainīt efektu %1 par %2",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "aizvietot %1 vienumu sarakstā %2 ar %3",
     "DATA_SHOWLIST": "rādīt sarakstu %1",
     "DATA_HIDELIST": "slēpt sarakstu %1",
-    "SENSING_OF_XPOSITION": "x pozīcija",
-    "SENSING_OF_YPOSITION": "y pozīcija",
-    "SENSING_OF_DIRECTION": "virziens",
+    "MOTION_XPOSITION": "x pozīcija",
+    "MOTION_YPOSITION": "y pozīcija",
+    "MOTION_DIRECTION": "virziens",
     "SENSING_OF_COSTUMENUMBER": "tērpa #",
     "LOOKS_COSTUMENUMBERNAME": "tērpa %1",
-    "SENSING_OF_SIZE": "izmērs",
+    "LOOKS_SIZE": "izmērs",
     "SENSING_OF_BACKDROPNAME": "fona nosaukums",
     "LOOKS_BACKDROPNUMBERNAME": "fona %1",
     "SENSING_OF_BACKDROPNUMBER": "fona #",
@@ -256,6 +256,5 @@
     "10 ^"
   ],
   "aliases": {},
-  "name": "Latviešu",
-  "percentTranslated": 100
+  "name": "Latviešu"
 }

--- a/locales/mi.json
+++ b/locales/mi.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "huna",
     "LOOKS_SWITCHCOSTUMETO": "panonitia te kākahu kia %1",
     "LOOKS_NEXTCOSTUME": "kākahu panuku",
-    "LOOKS_NEXTBACKDROP_BLOCK": "ārai tuarongo panuku",
+    "LOOKS_NEXTBACKDROP": "ārai tuarongo panuku",
     "LOOKS_SWITCHBACKDROPTO": "panonitia te ārai tuarongo kia %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "panonitia te ārai tuarongo kia %1, kātahi, tatari",
     "LOOKS_CHANGEEFFECTBY": "panonitia te rākeitanga %1 mā te %2",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "whakakapia te tūemi %1 o %2, ki %3",
     "DATA_SHOWLIST": "whakaaturia te rārangi %1",
     "DATA_HIDELIST": "hunāia te rārangi %1",
-    "SENSING_OF_XPOSITION": "tūnga x",
-    "SENSING_OF_YPOSITION": "tūnga y",
-    "SENSING_OF_DIRECTION": "ahunga",
+    "MOTION_XPOSITION": "tūnga x",
+    "MOTION_YPOSITION": "tūnga y",
+    "MOTION_DIRECTION": "ahunga",
     "SENSING_OF_COSTUMENUMBER": "kākahu #",
     "LOOKS_COSTUMENUMBERNAME": "kākahu %1",
-    "SENSING_OF_SIZE": "rahi",
+    "LOOKS_SIZE": "rahi",
     "SENSING_OF_BACKDROPNAME": "ingoa ārai tuarongo",
     "LOOKS_BACKDROPNUMBERNAME": "ārai tuarongo %1",
     "SENSING_OF_BACKDROPNUMBER": "ārai tuarongo #",
@@ -256,6 +256,5 @@
     "10 ^"
   ],
   "aliases": {},
-  "name": "Māori",
-  "percentTranslated": 100
+  "name": "Māori"
 }

--- a/locales/mn.json
+++ b/locales/mn.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "нуугд",
     "LOOKS_SWITCHCOSTUMETO": "өмсгөлийг %1 болгож соль",
     "LOOKS_NEXTCOSTUME": "дараах өмсгөл",
-    "LOOKS_NEXTBACKDROP_BLOCK": "дараах дэвсгэр",
+    "LOOKS_NEXTBACKDROP": "дараах дэвсгэр",
     "LOOKS_SWITCHBACKDROPTO": "Дэвсгэрийг %1 болгож өөрчил",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "Дэвсгэр %1 -рүү шилжээд хүлээ",
     "LOOKS_CHANGEEFFECTBY": "%1 нөлөөг %2 нэгжээр өөрчил",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "%2-н %1-г %3 болгож өөрчил",
     "DATA_SHOWLIST": "%1 жагсаалтыг харуул",
     "DATA_HIDELIST": "%1 жагсаалтыг нуу",
-    "SENSING_OF_XPOSITION": "x - н утга",
-    "SENSING_OF_YPOSITION": "y - н утга",
-    "SENSING_OF_DIRECTION": "чиглэл",
+    "MOTION_XPOSITION": "x - н утга",
+    "MOTION_YPOSITION": "y - н утга",
+    "MOTION_DIRECTION": "чиглэл",
     "SENSING_OF_COSTUMENUMBER": "өмсгөл #",
     "LOOKS_COSTUMENUMBERNAME": "Өмсгөл %1",
-    "SENSING_OF_SIZE": "хэмжээ",
+    "LOOKS_SIZE": "хэмжээ",
     "SENSING_OF_BACKDROPNAME": "дэвсгэрийн нэр",
     "LOOKS_BACKDROPNUMBERNAME": "Дэвсгэр %1",
     "SENSING_OF_BACKDROPNUMBER": "# дэвсгэр",
@@ -257,6 +257,5 @@
     "10 ^"
   ],
   "aliases": {},
-  "name": "Монгол хэл",
-  "percentTranslated": 100
+  "name": "Монгол хэл"
 }

--- a/locales/nb.json
+++ b/locales/nb.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "skjul",
     "LOOKS_SWITCHCOSTUMETO": "bytt drakt til %1",
     "LOOKS_NEXTCOSTUME": "neste drakt",
-    "LOOKS_NEXTBACKDROP_BLOCK": "neste bakgrunn",
+    "LOOKS_NEXTBACKDROP": "neste bakgrunn",
     "LOOKS_SWITCHBACKDROPTO": "bytt bakgrunn til %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "bytt bakgrunn til %1 og vent",
     "LOOKS_CHANGEEFFECTBY": "endre %1 effekt med %2",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "erstatt element %1 i %2 med %3",
     "DATA_SHOWLIST": "vis liste %1",
     "DATA_HIDELIST": "skjul liste %1",
-    "SENSING_OF_XPOSITION": "x-posisjon",
-    "SENSING_OF_YPOSITION": "y-posisjon",
-    "SENSING_OF_DIRECTION": "retning",
+    "MOTION_XPOSITION": "x-posisjon",
+    "MOTION_YPOSITION": "y-posisjon",
+    "MOTION_DIRECTION": "retning",
     "SENSING_OF_COSTUMENUMBER": "drakt nr.",
     "LOOKS_COSTUMENUMBERNAME": "drakt %1",
-    "SENSING_OF_SIZE": "størrelse",
+    "LOOKS_SIZE": "størrelse",
     "SENSING_OF_BACKDROPNAME": "navn på bakgrunn",
     "LOOKS_BACKDROPNUMBERNAME": "bakgrunn %1",
     "SENSING_OF_BACKDROPNUMBER": "bakgrunn nr.",
@@ -261,6 +261,5 @@
     "når grønt flagg klikkes": "EVENT_WHENFLAGCLICKED",
     "slutt": "scratchblocks:end"
   },
-  "name": "Norsk Bokmål",
-  "percentTranslated": 100
+  "name": "Norsk Bokmål"
 }

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "verdwijn",
     "LOOKS_SWITCHCOSTUMETO": "verander uiterlijk naar %1",
     "LOOKS_NEXTCOSTUME": "volgend uiterlijk",
-    "LOOKS_NEXTBACKDROP_BLOCK": "volgende achtergrond",
+    "LOOKS_NEXTBACKDROP": "volgende achtergrond",
     "LOOKS_SWITCHBACKDROPTO": "verander achtergrond naar %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "verander achtergrond naar %1 en wacht",
     "LOOKS_CHANGEEFFECTBY": "verander %1 effect met %2",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "vervang item %1 van %2 door %3",
     "DATA_SHOWLIST": "toon lijst %1",
     "DATA_HIDELIST": "verberg lijst %1",
-    "SENSING_OF_XPOSITION": "x-positie",
-    "SENSING_OF_YPOSITION": "y-positie",
-    "SENSING_OF_DIRECTION": "richting",
+    "MOTION_XPOSITION": "x-positie",
+    "MOTION_YPOSITION": "y-positie",
+    "MOTION_DIRECTION": "richting",
     "SENSING_OF_COSTUMENUMBER": "uiterlijk #",
     "LOOKS_COSTUMENUMBERNAME": "uiterlijk %1",
-    "SENSING_OF_SIZE": "grootte",
+    "LOOKS_SIZE": "grootte",
     "SENSING_OF_BACKDROPNAME": "achtergrond naam",
     "LOOKS_BACKDROPNUMBERNAME": "achtergrond %1",
     "SENSING_OF_BACKDROPNUMBER": "achtergrond #",
@@ -261,6 +261,5 @@
     "wanneer groene vlag wordt aangeklikt": "EVENT_WHENFLAGCLICKED",
     "einde": "scratchblocks:end"
   },
-  "name": "Nederlands",
-  "percentTranslated": 100
+  "name": "Nederlands"
 }

--- a/locales/nn.json
+++ b/locales/nn.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "gøym",
     "LOOKS_SWITCHCOSTUMETO": "byt drakt til %1",
     "LOOKS_NEXTCOSTUME": "neste drakt",
-    "LOOKS_NEXTBACKDROP_BLOCK": "neste bakgrunn",
+    "LOOKS_NEXTBACKDROP": "neste bakgrunn",
     "LOOKS_SWITCHBACKDROPTO": "byt bakgrunn til %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "byt bakgrunn til %1 og vent",
     "LOOKS_CHANGEEFFECTBY": "endra %1-effekten med %2",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "byt ut element %1 i %2 med %3",
     "DATA_SHOWLIST": "vis lista %1",
     "DATA_HIDELIST": "gøym lista %1",
-    "SENSING_OF_XPOSITION": "x-posisjon",
-    "SENSING_OF_YPOSITION": "y-posisjon",
-    "SENSING_OF_DIRECTION": "retning",
+    "MOTION_XPOSITION": "x-posisjon",
+    "MOTION_YPOSITION": "y-posisjon",
+    "MOTION_DIRECTION": "retning",
     "SENSING_OF_COSTUMENUMBER": "drakt nr.",
     "LOOKS_COSTUMENUMBERNAME": "drakt %1",
-    "SENSING_OF_SIZE": "storleik",
+    "LOOKS_SIZE": "storleik",
     "SENSING_OF_BACKDROPNAME": "bakgrunnsnamn",
     "LOOKS_BACKDROPNUMBERNAME": "bakgrunn %1",
     "SENSING_OF_BACKDROPNUMBER": "bakgrunn nr.",
@@ -256,6 +256,5 @@
     "10^"
   ],
   "aliases": {},
-  "name": "Norsk Nynorsk",
-  "percentTranslated": 100
+  "name": "Norsk Nynorsk"
 }

--- a/locales/nso.json
+++ b/locales/nso.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "fihla",
     "LOOKS_SWITCHCOSTUMETO": "fetolela khosetšhumo go %1",
     "LOOKS_NEXTCOSTUME": "khosetšhumo ye e latelago",
-    "LOOKS_NEXTBACKDROP_BLOCK": "bokamorago bjo bo latelago",
+    "LOOKS_NEXTBACKDROP": "bokamorago bjo bo latelago",
     "LOOKS_SWITCHBACKDROPTO": "fetola bokamorago go %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "fetola bokamorago go %1 gomme o lete",
     "LOOKS_CHANGEEFFECTBY": "fetola %1 khuetšo ka %2",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "tšhentšha selo %1 ya %2 ka %3",
     "DATA_SHOWLIST": "laetša lenaneo %1",
     "DATA_HIDELIST": "fihla lenaneo %1",
-    "SENSING_OF_XPOSITION": "boemo ba x",
-    "SENSING_OF_YPOSITION": "boemo ba y",
-    "SENSING_OF_DIRECTION": "thoko",
+    "MOTION_XPOSITION": "boemo ba x",
+    "MOTION_YPOSITION": "boemo ba y",
+    "MOTION_DIRECTION": "thoko",
     "SENSING_OF_COSTUMENUMBER": "khosetšhumo #",
     "LOOKS_COSTUMENUMBERNAME": "khosetšhumo %1",
-    "SENSING_OF_SIZE": "bogolo",
+    "LOOKS_SIZE": "bogolo",
     "SENSING_OF_BACKDROPNAME": "leina la bokamorago",
     "LOOKS_BACKDROPNUMBERNAME": "bokamorago%1",
     "SENSING_OF_BACKDROPNUMBER": "bokamorago #",
@@ -256,6 +256,5 @@
     "10 ^"
   ],
   "aliases": {},
-  "name": "Sepedi",
-  "percentTranslated": 100
+  "name": "Sepedi"
 }

--- a/locales/oc.json
+++ b/locales/oc.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "amagar",
     "LOOKS_SWITCHCOSTUMETO": "escambiar lo costum per %1",
     "LOOKS_NEXTCOSTUME": "costum seguent",
-    "LOOKS_NEXTBACKDROP_BLOCK": "fons seguent",
+    "LOOKS_NEXTBACKDROP": "fons seguent",
     "LOOKS_SWITCHBACKDROPTO": "escambiar lo fons per %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "escambiar fons per %1 e esperar",
     "LOOKS_CHANGEEFFECTBY": "cambiar %1 efièch per %2",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "remplaçar element %1 de %2 amb %3",
     "DATA_SHOWLIST": "mostrar tièra %1",
     "DATA_HIDELIST": "amagar tièra %1",
-    "SENSING_OF_XPOSITION": "posicion x",
-    "SENSING_OF_YPOSITION": "posicion y",
-    "SENSING_OF_DIRECTION": "direccion",
+    "MOTION_XPOSITION": "posicion x",
+    "MOTION_YPOSITION": "posicion y",
+    "MOTION_DIRECTION": "direccion",
     "SENSING_OF_COSTUMENUMBER": "costum #",
     "LOOKS_COSTUMENUMBERNAME": "costum %1",
-    "SENSING_OF_SIZE": "talha",
+    "LOOKS_SIZE": "talha",
     "SENSING_OF_BACKDROPNAME": "nom del fons",
     "LOOKS_BACKDROPNUMBERNAME": "fons %1",
     "SENSING_OF_BACKDROPNUMBER": "fons #",
@@ -256,6 +256,5 @@
     "10 ^"
   ],
   "aliases": {},
-  "name": "Occitan",
-  "percentTranslated": 100
+  "name": "Occitan"
 }

--- a/locales/or.json
+++ b/locales/or.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "ଲୁଚାଅ",
     "LOOKS_SWITCHCOSTUMETO": "ପୋଷାକ %1 କୁ ବଦଳାଇ ଦିଅ",
     "LOOKS_NEXTCOSTUME": "ପରବର୍ତୀ ପୋଷାକ",
-    "LOOKS_NEXTBACKDROP_BLOCK": "ପରବର୍ତୀ ପୃଷ୍ଠଭୂମି",
+    "LOOKS_NEXTBACKDROP": "ପରବର୍ତୀ ପୃଷ୍ଠଭୂମି",
     "LOOKS_SWITCHBACKDROPTO": "ପୃଷ୍ଠଭୂମି %1 କୁ ବଦଳାଅ",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "ପୃଷ୍ଠଭୂମି %1 କୁ ବଦଳାଅ ଓ ଅପେକ୍ଷା କର",
     "LOOKS_CHANGEEFFECTBY": "%1 ର ପ୍ରଭାବ କୁ %2 ଦ୍ବାରା ବଦଳାଅ",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "%2 ର %1 ତମ ବସ୍ତୁ କୁ %3 ଦ୍ବାରା ବଦଳାଇ ଦିଅ",
     "DATA_SHOWLIST": "%1 ତାଲିକା ଦେଖାଅ",
     "DATA_HIDELIST": "%1 ତାଲିକା ଲୁଚାଅ",
-    "SENSING_OF_XPOSITION": "x ସ୍ଥିତି",
-    "SENSING_OF_YPOSITION": "y ସ୍ଥିତି",
-    "SENSING_OF_DIRECTION": "ଦିଗ",
+    "MOTION_XPOSITION": "x ସ୍ଥିତି",
+    "MOTION_YPOSITION": "y ସ୍ଥିତି",
+    "MOTION_DIRECTION": "ଦିଗ",
     "SENSING_OF_COSTUMENUMBER": "ପୋଷାକ #",
     "LOOKS_COSTUMENUMBERNAME": "%1 ପୋଷାକ",
-    "SENSING_OF_SIZE": "ଆକାର",
+    "LOOKS_SIZE": "ଆକାର",
     "SENSING_OF_BACKDROPNAME": "ପୃଷ୍ଠଭୂମି ର ନାମ",
     "LOOKS_BACKDROPNUMBERNAME": "%1 ପୃଷ୍ଠଭୂମି",
     "SENSING_OF_BACKDROPNUMBER": "ପୃଷ୍ଠଭୂମି #",
@@ -257,6 +257,5 @@
     "10^"
   ],
   "aliases": {},
-  "name": "ଓଡ଼ିଆ",
-  "percentTranslated": 100
+  "name": "ଓଡ଼ିଆ"
 }

--- a/locales/pl.json
+++ b/locales/pl.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "ukryj",
     "LOOKS_SWITCHCOSTUMETO": "zmień kostium na %1",
     "LOOKS_NEXTCOSTUME": "następny kostium",
-    "LOOKS_NEXTBACKDROP_BLOCK": "następne tło",
+    "LOOKS_NEXTBACKDROP": "następne tło",
     "LOOKS_SWITCHBACKDROPTO": "zmień tło na %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "zmień tło na %1 i czekaj",
     "LOOKS_CHANGEEFFECTBY": "zmień efekt %1 o %2",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "zamień %1 z %2 na %3",
     "DATA_SHOWLIST": "pokaż listę %1",
     "DATA_HIDELIST": "ukryj listę %1",
-    "SENSING_OF_XPOSITION": "pozycja x",
-    "SENSING_OF_YPOSITION": "pozycja y",
-    "SENSING_OF_DIRECTION": "kierunek",
+    "MOTION_XPOSITION": "pozycja x",
+    "MOTION_YPOSITION": "pozycja y",
+    "MOTION_DIRECTION": "kierunek",
     "SENSING_OF_COSTUMENUMBER": "indeks kostiumu",
     "LOOKS_COSTUMENUMBERNAME": "kostium %1",
-    "SENSING_OF_SIZE": "rozmiar",
+    "LOOKS_SIZE": "rozmiar",
     "SENSING_OF_BACKDROPNAME": "nazwa tła",
     "LOOKS_BACKDROPNUMBERNAME": "tło %1",
     "SENSING_OF_BACKDROPNUMBER": "indeks tła",
@@ -261,6 +261,5 @@
     "kiedy kliknięto zieloną flagę": "EVENT_WHENFLAGCLICKED",
     "koniec": "scratchblocks:end"
   },
-  "name": "Polski",
-  "percentTranslated": 100
+  "name": "Polski"
 }

--- a/locales/pt-br.json
+++ b/locales/pt-br.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "esconda",
     "LOOKS_SWITCHCOSTUMETO": "mude para a fantasia %1",
     "LOOKS_NEXTCOSTUME": "próxima fantasia",
-    "LOOKS_NEXTBACKDROP_BLOCK": "próximo cenário",
+    "LOOKS_NEXTBACKDROP": "próximo cenário",
     "LOOKS_SWITCHBACKDROPTO": "mude para o cenário %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "mude para o cenário %1 e espere",
     "LOOKS_CHANGEEFFECTBY": "mude %2 ao efeito %1",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "substitua o item %1 de %2 por %3",
     "DATA_SHOWLIST": "mostre a lista %1",
     "DATA_HIDELIST": "esconda a lista %1",
-    "SENSING_OF_XPOSITION": "posição x",
-    "SENSING_OF_YPOSITION": "posição y",
-    "SENSING_OF_DIRECTION": "direção",
+    "MOTION_XPOSITION": "posição x",
+    "MOTION_YPOSITION": "posição y",
+    "MOTION_DIRECTION": "direção",
     "SENSING_OF_COSTUMENUMBER": "n° da fantasia",
     "LOOKS_COSTUMENUMBERNAME": "fantasia %1",
-    "SENSING_OF_SIZE": "tamanho",
+    "LOOKS_SIZE": "tamanho",
     "SENSING_OF_BACKDROPNAME": "nome do cenário",
     "LOOKS_BACKDROPNUMBERNAME": "cenário %1",
     "SENSING_OF_BACKDROPNUMBER": "n° do cenário",
@@ -256,6 +256,5 @@
     "10 elevado à"
   ],
   "aliases": {},
-  "name": "Português Brasileiro",
-  "percentTranslated": 100
+  "name": "Português Brasileiro"
 }

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "esconde-te",
     "LOOKS_SWITCHCOSTUMETO": "muda o teu traje para %1",
     "LOOKS_NEXTCOSTUME": "passa para o teu próximo traje",
-    "LOOKS_NEXTBACKDROP_BLOCK": "passa para o teu próximo cenário",
+    "LOOKS_NEXTBACKDROP": "passa para o teu próximo cenário",
     "LOOKS_SWITCHBACKDROPTO": "muda o cenário para %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "muda o cenário para %1 e espera",
     "LOOKS_CHANGEEFFECTBY": "adiciona ao teu efeito %1 o valor %2",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "substitui %1 de %2 por %3",
     "DATA_SHOWLIST": "mostra a lista %1",
     "DATA_HIDELIST": "esconde a lista %1",
-    "SENSING_OF_XPOSITION": "o x da posição",
-    "SENSING_OF_YPOSITION": "o y da posição",
-    "SENSING_OF_DIRECTION": "a direcção",
+    "MOTION_XPOSITION": "o x da tua posição",
+    "MOTION_YPOSITION": "o y da tua posição",
+    "MOTION_DIRECTION": "a direcção",
     "SENSING_OF_COSTUMENUMBER": "o número do traje",
     "LOOKS_COSTUMENUMBERNAME": "%1 do traje",
-    "SENSING_OF_SIZE": "o tamanho",
+    "LOOKS_SIZE": "o tamanho",
     "SENSING_OF_BACKDROPNAME": "o nome do cenário",
     "LOOKS_BACKDROPNUMBERNAME": "%1 do cenário",
     "SENSING_OF_BACKDROPNUMBER": "o número do cenário",
@@ -261,6 +261,5 @@
     "Quando alguém clicar na bandeira verde": "EVENT_WHENFLAGCLICKED",
     "fim": "scratchblocks:end"
   },
-  "name": "Português",
-  "percentTranslated": 100
+  "name": "Português"
 }

--- a/locales/qu.json
+++ b/locales/qu.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "pakay",
     "LOOKS_SWITCHCOSTUMETO": "tikray pachata %1",
     "LOOKS_NEXTCOSTUME": "huknin pacha",
-    "LOOKS_NEXTBACKDROP_BLOCK": "huk uku lliklla",
+    "LOOKS_NEXTBACKDROP": "huk uku lliklla",
     "LOOKS_SWITCHBACKDROPTO": "tikray ukuqillqayta %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "tikray ukuqillqayta %1 hinaspa suyay",
     "LOOKS_CHANGEEFFECTBY": "tikray %1 imayna rikuriqninta kaywan %2",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "kikraykuy chayta %1 kaymanta %2 kaywan %3",
     "DATA_SHOWLIST": "qawachiy qillqayta %1",
     "DATA_HIDELIST": "pakay qillqayta %1",
-    "SENSING_OF_XPOSITION": "x sayay",
-    "SENSING_OF_YPOSITION": "y sayay",
-    "SENSING_OF_DIRECTION": "maypi",
+    "MOTION_XPOSITION": "x sayay",
+    "MOTION_YPOSITION": "y sayay",
+    "MOTION_DIRECTION": "maypi",
     "SENSING_OF_COSTUMENUMBER": "pacha #",
     "LOOKS_COSTUMENUMBERNAME": "pacha %1",
-    "SENSING_OF_SIZE": "hatunin",
+    "LOOKS_SIZE": "hatunin",
     "SENSING_OF_BACKDROPNAME": "hipaynin sutin",
     "LOOKS_BACKDROPNUMBERNAME": "uku lliklla %1",
     "SENSING_OF_BACKDROPNUMBER": "hipaynin",
@@ -256,6 +256,5 @@
     "10 ^"
   ],
   "aliases": {},
-  "name": "Kichwa",
-  "percentTranslated": 100
+  "name": "Kichwa"
 }

--- a/locales/rap.json
+++ b/locales/rap.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "naʾa",
     "LOOKS_SWITCHCOSTUMETO": "ka kamiare te diseño ki te %1",
     "LOOKS_NEXTCOSTUME": "te rua diseño",
-    "LOOKS_NEXTBACKDROP_BLOCK": "te rua tuʾa nui",
+    "LOOKS_NEXTBACKDROP": "te rua tuʾa nui",
     "LOOKS_SWITCHBACKDROPTO": "ka kamiare te tuʾa nui ki te %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "kamiare te tuʾa nui ki te %1 e ka tiaki",
     "LOOKS_CHANGEEFFECTBY": "haka rahi te efecto %1 %2",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "ka hahaʾo te rua meʾe %1 o te %2 hai %3",
     "DATA_SHOWLIST": "haka tikeʾa te parau o te meʾe %1",
     "DATA_HIDELIST": "naʾa te parau %1",
-    "SENSING_OF_XPOSITION": "he noho o te x",
-    "SENSING_OF_YPOSITION": "he noho o te y",
-    "SENSING_OF_DIRECTION": "ara",
+    "MOTION_XPOSITION": "he noho o te x",
+    "MOTION_YPOSITION": "he noho o te y",
+    "MOTION_DIRECTION": "ara",
     "SENSING_OF_COSTUMENUMBER": "# o te diseño",
     "LOOKS_COSTUMENUMBERNAME": "%1 o te diseño",
-    "SENSING_OF_SIZE": "he haito",
+    "LOOKS_SIZE": "he haito",
     "SENSING_OF_BACKDROPNAME": "iŋoa o te tuʾa nui",
     "LOOKS_BACKDROPNUMBERNAME": "%1 o te tuʾa nui",
     "SENSING_OF_BACKDROPNUMBER": "o te tuʾa nui",
@@ -258,6 +258,5 @@
     "10 ^"
   ],
   "aliases": {},
-  "name": "Rapa Nui",
-  "percentTranslated": 100
+  "name": "Rapa Nui"
 }

--- a/locales/ro.json
+++ b/locales/ro.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "ascunde",
     "LOOKS_SWITCHCOSTUMETO": "schimbă costumul la %1",
     "LOOKS_NEXTCOSTUME": "costumul următor",
-    "LOOKS_NEXTBACKDROP_BLOCK": "decorul următor",
+    "LOOKS_NEXTBACKDROP": "decorul următor",
     "LOOKS_SWITCHBACKDROPTO": "schimbă decorul la %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "schimbă decorul la %1 și așteaptă",
     "LOOKS_CHANGEEFFECTBY": "modifică efectul %1 cu %2",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "înlocuiește item %1 din %2 cu %3",
     "DATA_SHOWLIST": "arată lista %1",
     "DATA_HIDELIST": "ascunde lista %1",
-    "SENSING_OF_XPOSITION": "poziția x",
-    "SENSING_OF_YPOSITION": "poziția y",
-    "SENSING_OF_DIRECTION": "direcția",
+    "MOTION_XPOSITION": "poziția x",
+    "MOTION_YPOSITION": "poziția y",
+    "MOTION_DIRECTION": "direcția",
     "SENSING_OF_COSTUMENUMBER": "nr. costum",
     "LOOKS_COSTUMENUMBERNAME": "costumul %1",
-    "SENSING_OF_SIZE": "mărime",
+    "LOOKS_SIZE": "mărime",
     "SENSING_OF_BACKDROPNAME": "denumire decor",
     "LOOKS_BACKDROPNUMBERNAME": "decor %1",
     "SENSING_OF_BACKDROPNUMBER": "nr. decor",
@@ -261,6 +261,5 @@
     "când se face click pe stegulețul verde": "EVENT_WHENFLAGCLICKED",
     "terminare": "scratchblocks:end"
   },
-  "name": "Română",
-  "percentTranslated": 100
+  "name": "Română"
 }

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "спрятаться",
     "LOOKS_SWITCHCOSTUMETO": "изменить костюм на %1",
     "LOOKS_NEXTCOSTUME": "следующий костюм",
-    "LOOKS_NEXTBACKDROP_BLOCK": "следующий фон",
+    "LOOKS_NEXTBACKDROP": "следующий фон",
     "LOOKS_SWITCHBACKDROPTO": "переключить фон на %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "переключить фон на %1 и ждать",
     "LOOKS_CHANGEEFFECTBY": "изменить эффект %1 на %2",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "заменить элемент %1 в %2 на %3",
     "DATA_SHOWLIST": "показать список %1",
     "DATA_HIDELIST": "скрыть список %1",
-    "SENSING_OF_XPOSITION": "положение x",
-    "SENSING_OF_YPOSITION": "положение y",
-    "SENSING_OF_DIRECTION": "направление",
+    "MOTION_XPOSITION": "положение x",
+    "MOTION_YPOSITION": "положение y",
+    "MOTION_DIRECTION": "направление",
     "SENSING_OF_COSTUMENUMBER": "костюм #",
     "LOOKS_COSTUMENUMBERNAME": "костюм %1",
-    "SENSING_OF_SIZE": "размер",
+    "LOOKS_SIZE": "размер",
     "SENSING_OF_BACKDROPNAME": "имя фона",
     "LOOKS_BACKDROPNUMBERNAME": "фон %1",
     "SENSING_OF_BACKDROPNUMBER": "фон #",
@@ -261,6 +261,5 @@
     "когда щёлкнут по зелёному флагу": "EVENT_WHENFLAGCLICKED",
     "конец": "scratchblocks:end"
   },
-  "name": "Русский",
-  "percentTranslated": 100
+  "name": "Русский"
 }

--- a/locales/sk.json
+++ b/locales/sk.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "skry sa",
     "LOOKS_SWITCHCOSTUMETO": "zmeň kostým na %1",
     "LOOKS_NEXTCOSTUME": "ďalší kostým",
-    "LOOKS_NEXTBACKDROP_BLOCK": "ďalšie pozadie",
+    "LOOKS_NEXTBACKDROP": "ďalšie pozadie",
     "LOOKS_SWITCHBACKDROPTO": "zmeň pozadie na %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "zmeň pozadie na %1 a počkaj",
     "LOOKS_CHANGEEFFECTBY": "zmeň efekt %1 o %2",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "nahraď %1 v %2 hodnotou %3",
     "DATA_SHOWLIST": "ukáž zoznam  %1",
     "DATA_HIDELIST": "skry zoznam  %1",
-    "SENSING_OF_XPOSITION": "pozícia x",
-    "SENSING_OF_YPOSITION": "pozícia y",
-    "SENSING_OF_DIRECTION": "smer",
+    "MOTION_XPOSITION": "pozícia x",
+    "MOTION_YPOSITION": "pozícia y",
+    "MOTION_DIRECTION": "smer",
     "SENSING_OF_COSTUMENUMBER": "číslo kostýmu",
     "LOOKS_COSTUMENUMBERNAME": "kostým %1",
-    "SENSING_OF_SIZE": "veľkosť",
+    "LOOKS_SIZE": "veľkosť",
     "SENSING_OF_BACKDROPNAME": "meno pozadia",
     "LOOKS_BACKDROPNUMBERNAME": "pozadie  %1",
     "SENSING_OF_BACKDROPNUMBER": "číslo pozadia",
@@ -256,6 +256,5 @@
     "10 ^"
   ],
   "aliases": {},
-  "name": "Slovenčina",
-  "percentTranslated": 100
+  "name": "Slovenčina"
 }

--- a/locales/sl.json
+++ b/locales/sl.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "skrij",
     "LOOKS_SWITCHCOSTUMETO": "spremeni videz v %1",
     "LOOKS_NEXTCOSTUME": "naslednji videz",
-    "LOOKS_NEXTBACKDROP_BLOCK": "naslednje ozadje",
+    "LOOKS_NEXTBACKDROP": "naslednje ozadje",
     "LOOKS_SWITCHBACKDROPTO": "zamenjaj ozadje na %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "zamenjaj ozadje na %1 in počakaj",
     "LOOKS_CHANGEEFFECTBY": "spremeni učinek %1 za %2",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "zamenjaj %1 v %2 z %3",
     "DATA_SHOWLIST": "pokaži seznam %1",
     "DATA_HIDELIST": "skrij seznam %1",
-    "SENSING_OF_XPOSITION": "položaj x",
-    "SENSING_OF_YPOSITION": "položaj y",
-    "SENSING_OF_DIRECTION": "smer",
+    "MOTION_XPOSITION": "položaj x",
+    "MOTION_YPOSITION": "položaj y",
+    "MOTION_DIRECTION": "smer",
     "SENSING_OF_COSTUMENUMBER": "videz #",
     "LOOKS_COSTUMENUMBERNAME": "videz %1",
-    "SENSING_OF_SIZE": "velikost",
+    "LOOKS_SIZE": "velikost",
     "SENSING_OF_BACKDROPNAME": "ime ozadja",
     "LOOKS_BACKDROPNUMBERNAME": "ozadje %1",
     "SENSING_OF_BACKDROPNUMBER": "ozadje #",
@@ -261,6 +261,5 @@
     "ko je kliknjena zelena zastavica": "EVENT_WHENFLAGCLICKED",
     "ustavi": "scratchblocks:end"
   },
-  "name": "Slovenščina",
-  "percentTranslated": 100
+  "name": "Slovenščina"
 }

--- a/locales/sr.json
+++ b/locales/sr.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "сакриј",
     "LOOKS_SWITCHCOSTUMETO": "замени костим са %1",
     "LOOKS_NEXTCOSTUME": "следећи костим",
-    "LOOKS_NEXTBACKDROP_BLOCK": "следећа позадина",
+    "LOOKS_NEXTBACKDROP": "следећа позадина",
     "LOOKS_SWITCHBACKDROPTO": "промени позадину у %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "промени позадину у %1 и чекај",
     "LOOKS_CHANGEEFFECTBY": "промени ефекат %1 за %2",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "замени елемент %1 у %2 са %3",
     "DATA_SHOWLIST": "прикажи листу %1",
     "DATA_HIDELIST": "сакриј листу %1",
-    "SENSING_OF_XPOSITION": "x положај",
-    "SENSING_OF_YPOSITION": "y положај",
-    "SENSING_OF_DIRECTION": "смер",
+    "MOTION_XPOSITION": "место х",
+    "MOTION_YPOSITION": "место у",
+    "MOTION_DIRECTION": "смер",
     "SENSING_OF_COSTUMENUMBER": "број костима",
     "LOOKS_COSTUMENUMBERNAME": "костим %1",
-    "SENSING_OF_SIZE": "величина",
+    "LOOKS_SIZE": "величина",
     "SENSING_OF_BACKDROPNAME": "име позадине",
     "LOOKS_BACKDROPNUMBERNAME": "позадина %1",
     "SENSING_OF_BACKDROPNUMBER": "број позадине",
@@ -256,6 +256,5 @@
     "10 ^"
   ],
   "aliases": {},
-  "name": "Српски",
-  "percentTranslated": 100
+  "name": "Српски"
 }

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "göm",
     "LOOKS_SWITCHCOSTUMETO": "ändra klädsel till %1",
     "LOOKS_NEXTCOSTUME": "nästa klädsel",
-    "LOOKS_NEXTBACKDROP_BLOCK": "nästa bakgrund",
+    "LOOKS_NEXTBACKDROP": "nästa bakgrund",
     "LOOKS_SWITCHBACKDROPTO": "växla bakgrund till %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "byt bakgrund till %1 och vänta",
     "LOOKS_CHANGEEFFECTBY": "ändra %1 effekten med %2",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "ersätt posten %1 i %2 med %3",
     "DATA_SHOWLIST": "visa listan %1",
     "DATA_HIDELIST": "göm listan %1",
-    "SENSING_OF_XPOSITION": "x position",
-    "SENSING_OF_YPOSITION": "y position",
-    "SENSING_OF_DIRECTION": "riktning",
+    "MOTION_XPOSITION": "x position",
+    "MOTION_YPOSITION": "y position",
+    "MOTION_DIRECTION": "riktning",
     "SENSING_OF_COSTUMENUMBER": "klädselnummer",
     "LOOKS_COSTUMENUMBERNAME": "klädsel %1",
-    "SENSING_OF_SIZE": "storlek",
+    "LOOKS_SIZE": "storlek",
     "SENSING_OF_BACKDROPNAME": "bakgrundsnamn",
     "LOOKS_BACKDROPNUMBERNAME": "bakgrund %1",
     "SENSING_OF_BACKDROPNUMBER": "bakgrundsnummer",
@@ -256,6 +256,5 @@
     "10 ^"
   ],
   "aliases": {},
-  "name": "Svenska",
-  "percentTranslated": 100
+  "name": "Svenska"
 }

--- a/locales/sw.json
+++ b/locales/sw.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "ficha",
     "LOOKS_SWITCHCOSTUMETO": "badilisha mtindo kuwa %1",
     "LOOKS_NEXTCOSTUME": "mtindo ufuatao",
-    "LOOKS_NEXTBACKDROP_BLOCK": "mandhari ya nyuma ifuatayo",
+    "LOOKS_NEXTBACKDROP": "mandhari ya nyuma ifuatayo",
     "LOOKS_SWITCHBACKDROPTO": "badilisha mandhari ya nyuma iwe %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "badilisha mandhari ya nyuma kuwa %1 na subiri",
     "LOOKS_CHANGEEFFECTBY": "badilisha athari ya %1 kwa %2",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "badilisha kipengee %1 kati ya %2 na %3",
     "DATA_SHOWLIST": "onyesha orodha %1",
     "DATA_HIDELIST": "ficha orodha %1",
-    "SENSING_OF_XPOSITION": "nafasi ya x",
-    "SENSING_OF_YPOSITION": "nafasi ya y",
-    "SENSING_OF_DIRECTION": "mwelekeo",
+    "MOTION_XPOSITION": "nafasi ya x",
+    "MOTION_YPOSITION": "nafasi ya y",
+    "MOTION_DIRECTION": "mwelekeo",
     "SENSING_OF_COSTUMENUMBER": "mtindo #",
     "LOOKS_COSTUMENUMBERNAME": "mtindo %1",
-    "SENSING_OF_SIZE": "ukubwa",
+    "LOOKS_SIZE": "ukubwa",
     "SENSING_OF_BACKDROPNAME": "jina la mandhari ya nyuma",
     "LOOKS_BACKDROPNUMBERNAME": "mandhari ya nyuma %1",
     "SENSING_OF_BACKDROPNUMBER": "mandhari ya nyuma #",
@@ -256,6 +256,5 @@
     "10 ^"
   ],
   "aliases": {},
-  "name": "Kiswahili",
-  "percentTranslated": 100
+  "name": "Kiswahili"
 }

--- a/locales/th.json
+++ b/locales/th.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "ซ่อน",
     "LOOKS_SWITCHCOSTUMETO": "เปลี่ยนคอสตูมเป็น %1",
     "LOOKS_NEXTCOSTUME": "ชุดถัดไป",
-    "LOOKS_NEXTBACKDROP_BLOCK": "ฉากหลังต่อไป",
+    "LOOKS_NEXTBACKDROP": "ฉากหลังต่อไป",
     "LOOKS_SWITCHBACKDROPTO": "เปลี่ยนฉากหลังเป็น %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "เปลี่ยนฉากหลังเป็น %1 และรอ",
     "LOOKS_CHANGEEFFECTBY": "เปลี่ยนเอฟเฟกต์ %1 ทีละ %2",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "แทนที่รายการที่ %1 ของ %2 ด้วย %3",
     "DATA_SHOWLIST": "แสดงรายการ %1",
     "DATA_HIDELIST": "ซ่อนรายการ %1",
-    "SENSING_OF_XPOSITION": "ตำแหน่ง x",
-    "SENSING_OF_YPOSITION": "ตำแหน่ง y",
-    "SENSING_OF_DIRECTION": "ทิศทาง",
+    "MOTION_XPOSITION": "ตำแหน่ง x",
+    "MOTION_YPOSITION": "ตำแหน่ง y",
+    "MOTION_DIRECTION": "ทิศทาง",
     "SENSING_OF_COSTUMENUMBER": "คอสตูม #",
     "LOOKS_COSTUMENUMBERNAME": "คอสตูม %1",
-    "SENSING_OF_SIZE": "ขนาด",
+    "LOOKS_SIZE": "ขนาด",
     "SENSING_OF_BACKDROPNAME": "ชื่อฉากหลัง",
     "LOOKS_BACKDROPNUMBERNAME": "ฉากหลัง %1",
     "SENSING_OF_BACKDROPNUMBER": "ฉากหลัง #",
@@ -256,6 +256,5 @@
     "10 ^"
   ],
   "aliases": {},
-  "name": "ไทย",
-  "percentTranslated": 100
+  "name": "ไทย"
 }

--- a/locales/tn.json
+++ b/locales/tn.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "fitlha",
     "LOOKS_SWITCHCOSTUMETO": "fetolela diaparo go %1",
     "LOOKS_NEXTCOSTUME": "seaparo se se latelang",
-    "LOOKS_NEXTBACKDROP_BLOCK": "tatlhelomorago e e latelang",
+    "LOOKS_NEXTBACKDROP": "tatlhelomorago e e latelang",
     "LOOKS_SWITCHBACKDROPTO": "fetolela tatlhelo morago go %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "fetolela tatlhelomorago go %1 mme o lete",
     "LOOKS_CHANGEEFFECTBY": "fetola %1 go simolola ka %2",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "emisetsa selwana %1 ya %2 ka %3",
     "DATA_SHOWLIST": "bontsha lenaane %1",
     "DATA_HIDELIST": "fitlha lenaane %1",
-    "SENSING_OF_XPOSITION": "boemo jwa x",
-    "SENSING_OF_YPOSITION": "boemo jwa y",
-    "SENSING_OF_DIRECTION": "kaelo",
+    "MOTION_XPOSITION": "boemo jwa x",
+    "MOTION_YPOSITION": "boemo jwa y",
+    "MOTION_DIRECTION": "kaelo",
     "SENSING_OF_COSTUMENUMBER": "seaparo #",
     "LOOKS_COSTUMENUMBERNAME": "seaparo %1",
-    "SENSING_OF_SIZE": "bogolo",
+    "LOOKS_SIZE": "bogolo",
     "SENSING_OF_BACKDROPNAME": "leina la tatlhelo morago",
     "LOOKS_BACKDROPNUMBERNAME": "tatlhelomorago %1",
     "SENSING_OF_BACKDROPNUMBER": "tatlhelo morago #",
@@ -256,6 +256,5 @@
     "10 ^"
   ],
   "aliases": {},
-  "name": "Setswana",
-  "percentTranslated": 100
+  "name": "Setswana"
 }

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "gizle",
     "LOOKS_SWITCHCOSTUMETO": "%1 kılığına geç",
     "LOOKS_NEXTCOSTUME": "sonraki kostüm",
-    "LOOKS_NEXTBACKDROP_BLOCK": "sonraki dekor",
+    "LOOKS_NEXTBACKDROP": "sonraki dekor",
     "LOOKS_SWITCHBACKDROPTO": "%1 dekoruna geç",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "%1 dekoruna geç ve bekle",
     "LOOKS_CHANGEEFFECTBY": "%1 etkisini %2 değiştir",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "%2 öğesinin %1 öğesini %3 ile değiştir",
     "DATA_SHOWLIST": "%1 listesini göster",
     "DATA_HIDELIST": "%1 listesini gizle",
-    "SENSING_OF_XPOSITION": "x konumu",
-    "SENSING_OF_YPOSITION": "y konumu",
-    "SENSING_OF_DIRECTION": "yön",
+    "MOTION_XPOSITION": "x konumu",
+    "MOTION_YPOSITION": "y konumu",
+    "MOTION_DIRECTION": "yön",
     "SENSING_OF_COSTUMENUMBER": "kostüm #",
     "LOOKS_COSTUMENUMBERNAME": "kostüm %1",
-    "SENSING_OF_SIZE": "büyüklük",
+    "LOOKS_SIZE": "büyüklük",
     "SENSING_OF_BACKDROPNAME": "dekorun adı",
     "LOOKS_BACKDROPNUMBERNAME": "dekor %1",
     "SENSING_OF_BACKDROPNUMBER": "dekor #",
@@ -264,6 +264,5 @@
     "yeşil bayrak tıklandığında": "EVENT_WHENFLAGCLICKED",
     "son": "scratchblocks:end"
   },
-  "name": "Türkçe",
-  "percentTranslated": 100
+  "name": "Türkçe"
 }

--- a/locales/uk.json
+++ b/locales/uk.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "сховати",
     "LOOKS_SWITCHCOSTUMETO": "змінити образ на %1",
     "LOOKS_NEXTCOSTUME": "наступний образ",
-    "LOOKS_NEXTBACKDROP_BLOCK": "наступне тло",
+    "LOOKS_NEXTBACKDROP": "наступне тло",
     "LOOKS_SWITCHBACKDROPTO": "змінити тло на %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "змінити тло на %1 та чекати",
     "LOOKS_CHANGEEFFECTBY": "змінити ефект %1 на %2",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "замінити елемент %1 в %2 на %3",
     "DATA_SHOWLIST": "показати список %1",
     "DATA_HIDELIST": "сховати список %1",
-    "SENSING_OF_XPOSITION": "значення x",
-    "SENSING_OF_YPOSITION": "значення y",
-    "SENSING_OF_DIRECTION": "напрям",
+    "MOTION_XPOSITION": "значення x",
+    "MOTION_YPOSITION": "значення y",
+    "MOTION_DIRECTION": "напрям",
     "SENSING_OF_COSTUMENUMBER": "образ #",
     "LOOKS_COSTUMENUMBERNAME": "образ %1",
-    "SENSING_OF_SIZE": "розмір",
+    "LOOKS_SIZE": "розмір",
     "SENSING_OF_BACKDROPNAME": "ім’я тла",
     "LOOKS_BACKDROPNUMBERNAME": "тло %1",
     "SENSING_OF_BACKDROPNUMBER": "тло #",
@@ -256,6 +256,5 @@
     "10 ^"
   ],
   "aliases": {},
-  "name": "Українська",
-  "percentTranslated": 100
+  "name": "Українська"
 }

--- a/locales/uz.json
+++ b/locales/uz.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "yashirish",
     "LOOKS_SWITCHCOSTUMETO": "ko'rinishni %1 ga o'zgartir",
     "LOOKS_NEXTCOSTUME": "keyingi ko'rinish",
-    "LOOKS_NEXTBACKDROP_BLOCK": "keyingi fon",
+    "LOOKS_NEXTBACKDROP": "keyingi fon",
     "LOOKS_SWITCHBACKDROPTO": "fonni %1 ga o'zgartir",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "%1 fonga o'zgartirib kutish",
     "LOOKS_CHANGEEFFECTBY": "%1 effektni %2 ga o'zgartir",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "%2 ro'yxatning %1 chi mavzusini %3 ga o'zgartirish",
     "DATA_SHOWLIST": "%1 ro'yxatni ko'rsatish",
     "DATA_HIDELIST": "%1 ro'yxatni yashirish",
-    "SENSING_OF_XPOSITION": "X koordinatasi",
-    "SENSING_OF_YPOSITION": "Y koordinatasi",
-    "SENSING_OF_DIRECTION": "yo'nalish",
+    "MOTION_XPOSITION": "x koordinatasi",
+    "MOTION_YPOSITION": "y koordinatasi",
+    "MOTION_DIRECTION": "yo'nalish",
     "SENSING_OF_COSTUMENUMBER": "kostyum #",
     "LOOKS_COSTUMENUMBERNAME": "ko'rinish %1",
-    "SENSING_OF_SIZE": "o'lcham",
+    "LOOKS_SIZE": "o'lcham",
     "SENSING_OF_BACKDROPNAME": "fonning nomi",
     "LOOKS_BACKDROPNUMBERNAME": "fon %1",
     "SENSING_OF_BACKDROPNUMBER": "fonning soni",
@@ -257,6 +257,5 @@
     "10 ^"
   ],
   "aliases": {},
-  "name": "Oʻzbekcha",
-  "percentTranslated": 100
+  "name": "Oʻzbekcha"
 }

--- a/locales/vi.json
+++ b/locales/vi.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "ẩn",
     "LOOKS_SWITCHCOSTUMETO": "chuyển sang trang phục %1",
     "LOOKS_NEXTCOSTUME": "trang phục kế tiếp",
-    "LOOKS_NEXTBACKDROP_BLOCK": "phông nền tiếp theo",
+    "LOOKS_NEXTBACKDROP": "phông nền tiếp theo",
     "LOOKS_SWITCHBACKDROPTO": "đổi phông nền thành %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "đổi phông nền thành %1 và đợi",
     "LOOKS_CHANGEEFFECTBY": "thay đổi hiệu ứng %1 một lượng %2",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "thay thế phần tử thứ %1 của danh sách %2 bằng %3",
     "DATA_SHOWLIST": "hiện danh sách %1",
     "DATA_HIDELIST": "ẩn danh sách %1",
-    "SENSING_OF_XPOSITION": "tọa độ x",
-    "SENSING_OF_YPOSITION": "tọa độ y",
-    "SENSING_OF_DIRECTION": "hướng",
+    "MOTION_XPOSITION": "tọa độ x",
+    "MOTION_YPOSITION": "tọa độ y",
+    "MOTION_DIRECTION": "hướng",
     "SENSING_OF_COSTUMENUMBER": "trang phục #",
     "LOOKS_COSTUMENUMBERNAME": "trang phục %1",
-    "SENSING_OF_SIZE": "kích thước",
+    "LOOKS_SIZE": "kích thước",
     "SENSING_OF_BACKDROPNAME": "tên phông nền",
     "LOOKS_BACKDROPNUMBERNAME": "phông nền %1",
     "SENSING_OF_BACKDROPNUMBER": "phông nền #",
@@ -257,6 +257,5 @@
     "10 ^"
   ],
   "aliases": {},
-  "name": "Tiếng Việt",
-  "percentTranslated": 100
+  "name": "Tiếng Việt"
 }

--- a/locales/xh.json
+++ b/locales/xh.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "fihla",
     "LOOKS_SWITCHCOSTUMETO": "guqulela ikhostyum ku %1",
     "LOOKS_NEXTCOSTUME": "elandelayo ikhostyum",
-    "LOOKS_NEXTBACKDROP_BLOCK": "umva olandelayo",
+    "LOOKS_NEXTBACKDROP": "umva olandelayo",
     "LOOKS_SWITCHBACKDROPTO": "guqulelaa umva ku %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "guqula umva %1 ulinde",
     "LOOKS_CHANGEEFFECTBY": "guqula %1 ifuthe ngo %2",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "beka endaweni yento %1 ka %2 u %3",
     "DATA_SHOWLIST": "bonisa uluhlu %1",
     "DATA_HIDELIST": "fihla uluhlu %1",
-    "SENSING_OF_XPOSITION": "indawo x",
-    "SENSING_OF_YPOSITION": "indawo y",
-    "SENSING_OF_DIRECTION": "ikhondo",
+    "MOTION_XPOSITION": "indawo ka x",
+    "MOTION_YPOSITION": "indawo ka y",
+    "MOTION_DIRECTION": "ulwalathiso",
     "SENSING_OF_COSTUMENUMBER": "ikhostyum #",
     "LOOKS_COSTUMENUMBERNAME": "ikhostyum %1",
-    "SENSING_OF_SIZE": "ubungakanani",
+    "LOOKS_SIZE": "ubungakanani",
     "SENSING_OF_BACKDROPNAME": "ingama lomva",
     "LOOKS_BACKDROPNUMBERNAME": "umva %1",
     "SENSING_OF_BACKDROPNUMBER": "umva",
@@ -256,6 +256,5 @@
     "10 ^"
   ],
   "aliases": {},
-  "name": "isiXhosa",
-  "percentTranslated": 100
+  "name": "isiXhosa"
 }

--- a/locales/zh-cn.json
+++ b/locales/zh-cn.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "隐藏",
     "LOOKS_SWITCHCOSTUMETO": "换成 %1 造型",
     "LOOKS_NEXTCOSTUME": "下一个造型",
-    "LOOKS_NEXTBACKDROP_BLOCK": "下一个背景",
+    "LOOKS_NEXTBACKDROP": "下一个背景",
     "LOOKS_SWITCHBACKDROPTO": "换成 %1 背景",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "换成 %1 背景并等待",
     "LOOKS_CHANGEEFFECTBY": "将 %1 特效增加 %2",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "将 %2 的第 %1 项替换为 %3",
     "DATA_SHOWLIST": "显示列表 %1",
     "DATA_HIDELIST": "隐藏列表 %1",
-    "SENSING_OF_XPOSITION": "x 坐标",
-    "SENSING_OF_YPOSITION": "y 坐标",
-    "SENSING_OF_DIRECTION": "方向",
+    "MOTION_XPOSITION": "x 坐标",
+    "MOTION_YPOSITION": "y 坐标",
+    "MOTION_DIRECTION": "方向",
     "SENSING_OF_COSTUMENUMBER": "造型编号",
     "LOOKS_COSTUMENUMBERNAME": "造型 %1",
-    "SENSING_OF_SIZE": "大小",
+    "LOOKS_SIZE": "大小",
     "SENSING_OF_BACKDROPNAME": "背景名称",
     "LOOKS_BACKDROPNUMBERNAME": "背景 %1",
     "SENSING_OF_BACKDROPNUMBER": "背景编号",
@@ -261,6 +261,5 @@
     "点击绿旗时": "EVENT_WHENFLAGCLICKED",
     "结束": "scratchblocks:end"
   },
-  "name": "简体中文",
-  "percentTranslated": 100
+  "name": "简体中文"
 }

--- a/locales/zh-tw.json
+++ b/locales/zh-tw.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "隱藏",
     "LOOKS_SWITCHCOSTUMETO": "造型換成 %1",
     "LOOKS_NEXTCOSTUME": "造型換成下一個",
-    "LOOKS_NEXTBACKDROP_BLOCK": "背景換成下一個",
+    "LOOKS_NEXTBACKDROP": "下一個背景",
     "LOOKS_SWITCHBACKDROPTO": "背景換成 %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "背景換成 %1 並等待",
     "LOOKS_CHANGEEFFECTBY": "圖像效果 %1 改變 %2",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "替換 %2 的第 %1 項為 %3",
     "DATA_SHOWLIST": "清單 %1 顯示",
     "DATA_HIDELIST": "清單 %1 隱藏",
-    "SENSING_OF_XPOSITION": "x 座標",
-    "SENSING_OF_YPOSITION": "y 座標",
-    "SENSING_OF_DIRECTION": "方向",
+    "MOTION_XPOSITION": "x 座標",
+    "MOTION_YPOSITION": "y 座標",
+    "MOTION_DIRECTION": "方向",
     "SENSING_OF_COSTUMENUMBER": "造型編號",
     "LOOKS_COSTUMENUMBERNAME": "造型 %1",
-    "SENSING_OF_SIZE": "尺寸",
+    "LOOKS_SIZE": "尺寸",
     "SENSING_OF_BACKDROPNAME": "背景名稱",
     "LOOKS_BACKDROPNUMBERNAME": "背景 %1",
     "SENSING_OF_BACKDROPNUMBER": "背景編號",
@@ -261,6 +261,5 @@
     "當綠旗被點擊時": "EVENT_WHENFLAGCLICKED",
     "結束": "scratchblocks:end"
   },
-  "name": "繁體中文",
-  "percentTranslated": 100
+  "name": "繁體中文"
 }

--- a/locales/zu.json
+++ b/locales/zu.json
@@ -22,7 +22,7 @@
     "LOOKS_HIDE": "fihla",
     "LOOKS_SWITCHCOSTUMETO": "shintsha impahla iyeku %1",
     "LOOKS_NEXTCOSTUME": "impahla elandelayo",
-    "LOOKS_NEXTBACKDROP_BLOCK": "okwasemuva okulandelayo",
+    "LOOKS_NEXTBACKDROP": "okwasemuva okulandelayo",
     "LOOKS_SWITCHBACKDROPTO": "shintsha okwasemuva ukuyise kwi %1",
     "LOOKS_SWITCHBACKDROPTOANDWAIT": "shintsha okwasemuva ukuse ku %1 besulinda",
     "LOOKS_CHANGEEFFECTBY": "shintsha  umphumela ongu %1 ngo  %2",
@@ -95,12 +95,12 @@
     "DATA_REPLACEITEMOFLIST": "faka okunye esikhundleni %1 ku %2 ngo %3",
     "DATA_SHOWLIST": "khombisa uhlu %1",
     "DATA_HIDELIST": "fihla uluhlu le %1",
-    "SENSING_OF_XPOSITION": "indawo ka-x",
-    "SENSING_OF_YPOSITION": "Indawo ka-y",
-    "SENSING_OF_DIRECTION": "indlela",
+    "MOTION_XPOSITION": "indawo ka- x",
+    "MOTION_YPOSITION": "indawo ka-y",
+    "MOTION_DIRECTION": "indlela",
     "SENSING_OF_COSTUMENUMBER": "impahla #",
     "LOOKS_COSTUMENUMBERNAME": "impahla %1",
-    "SENSING_OF_SIZE": "ubukhulu",
+    "LOOKS_SIZE": "Isisindo / Ubukhulu",
     "SENSING_OF_BACKDROPNAME": "igama lokwasemuva",
     "LOOKS_BACKDROPNUMBERNAME": "okwasemuva %1",
     "SENSING_OF_BACKDROPNUMBER": "okwasemuva #",
@@ -256,6 +256,5 @@
     "10 ^"
   ],
   "aliases": {},
-  "name": "isiZulu",
-  "percentTranslated": 100
+  "name": "isiZulu"
 }

--- a/syntax/commands.js
+++ b/syntax/commands.js
@@ -773,7 +773,7 @@ export default [
     category: "list",
   },
   {
-    id: "SENSING_OF_XPOSITION",
+    id: "MOTION_XPOSITION",
     selector: "xpos",
     spec: "x position",
     inputs: [],
@@ -781,7 +781,7 @@ export default [
     category: "motion",
   },
   {
-    id: "SENSING_OF_YPOSITION",
+    id: "MOTION_YPOSITION",
     selector: "ypos",
     spec: "y position",
     inputs: [],
@@ -789,7 +789,7 @@ export default [
     category: "motion",
   },
   {
-    id: "SENSING_OF_DIRECTION",
+    id: "MOTION_DIRECTION",
     selector: "heading",
     spec: "direction",
     inputs: [],
@@ -797,7 +797,7 @@ export default [
     category: "motion",
   },
   {
-    id: "SENSING_OF_COSTUMENUMBER",
+    id: "LOOKS_COSTUMENUMBERNAME", // TODO
     selector: "costumeIndex",
     spec: "costume #",
     inputs: [],
@@ -813,7 +813,7 @@ export default [
     category: "looks",
   },
   {
-    id: "SENSING_OF_SIZE",
+    id: "LOOKS_SIZE",
     selector: "scale",
     spec: "size",
     inputs: [],
@@ -821,7 +821,7 @@ export default [
     category: "looks",
   },
   {
-    id: "SENSING_OF_BACKDROPNAME",
+    id: "LOOKS_BACKDROPNUMBERNAME", // TODO
     selector: "sceneName",
     spec: "backdrop name",
     inputs: [],
@@ -836,7 +836,7 @@ export default [
     category: "looks",
   },
   {
-    id: "SENSING_OF_BACKDROPNUMBER",
+    id: "LOOKS_BACKDROPNUMBERNAME",
     selector: "backgroundIndex",
     spec: "backdrop #",
     inputs: [],

--- a/syntax/commands.js
+++ b/syntax/commands.js
@@ -175,7 +175,7 @@ export default [
     category: "looks",
   },
   {
-    id: "LOOKS_NEXTBACKDROP_BLOCK",
+    id: "LOOKS_NEXTBACKDROP",
     selector: "nextScene",
     spec: "next backdrop",
     inputs: [],
@@ -375,8 +375,8 @@ export default [
     category: "sound",
   },
   {
+    // The Scratch 3 version of this block omits the word "bpm".
     id: "music.setTempo",
-    selector: "setTempoTo:",
     spec: "set tempo to %1",
     inputs: ["%n"],
     shape: "stack",
@@ -797,7 +797,9 @@ export default [
     category: "motion",
   },
   {
-    id: "LOOKS_COSTUMENUMBERNAME", // TODO
+    // This reporter block no longer exists in Scratch 3; so instead we cheat
+    // and use the menu option from the "_ of _" block.
+    id: "SENSING_OF_COSTUMENUMBER",
     selector: "costumeIndex",
     spec: "costume #",
     inputs: [],
@@ -805,8 +807,8 @@ export default [
     category: "looks",
   },
   {
+    // New for Scratch 3.
     id: "LOOKS_COSTUMENUMBERNAME",
-    selector: "LOOKS_COSTUMENUMBERNAME",
     spec: "costume %1",
     inputs: ["%m"],
     shape: "reporter",
@@ -821,7 +823,9 @@ export default [
     category: "looks",
   },
   {
-    id: "LOOKS_BACKDROPNUMBERNAME", // TODO
+    // This reporter block no longer exists in Scratch 3; so instead we cheat
+    // and use the menu option from the "_ of _" block.
+    id: "SENSING_OF_BACKDROPNAME",
     selector: "sceneName",
     spec: "backdrop name",
     inputs: [],
@@ -829,6 +833,7 @@ export default [
     category: "looks",
   },
   {
+    // New for Scratch 3.
     id: "LOOKS_BACKDROPNUMBERNAME",
     spec: "backdrop %1",
     inputs: ["%m"],
@@ -836,7 +841,9 @@ export default [
     category: "looks",
   },
   {
-    id: "LOOKS_BACKDROPNUMBERNAME",
+    // This reporter block no longer exists in Scratch 3; so instead we cheat
+    // and use the menu option from the "_ of _" block.
+    id: "SENSING_OF_BACKDROPNUMBER",
     selector: "backgroundIndex",
     spec: "backdrop #",
     inputs: [],


### PR DESCRIPTION
This change will fix #505: for the (size) block, we're incorrectly using the `SENSING_OF_SIZE` translation key, rather than the correct `LOOKS_SIZE`. This meant that we chose the wrong translation in some cases (e.g. isiZulu).

I've also corrected a few other incorrect translation keys. I did this by reviewing the differences in selectors between scratchblocks, and the Scratch 2 -> Scratch 3 [mapping used](https://github.com/scratchfoundation/scratch-vm/blob/6c0c7a5a2fee93e4e1e862f7a309b73d0d6c126e/src/serialization/sb2_specmap.js) inside `scratch-vm`, with the help of the following script:
```js
import commands from './syntax/commands.js'
import specMap from './sb2_specmap.cjs'

for (const cmd of commands) {
  const { category, selector, id: actualId, spec } = cmd
  if (selector == null) {
    continue // Some blocks are only in Scratch 3.0, and have no Scratch 2.0 selector.
  }
  if (category === 'obsolete') {
    continue // Ignore Scratch 1.4 blocks.
  }

  const map = specMap[selector]
  let expectedId = (map?.opcode ?? '').toUpperCase()

  // The operator translation keys are spelt different from the block IDs.
  expectedId = expectedId.replace(/^OPERATOR_/, 'OPERATORS_')
  // So are the Control blocks.
  if (/CONTROL_/.test(expectedId)) {
    expectedId = 'CONTROL_' + expectedId.slice('CONTROL_'.length).replace(/_/g, '')
  }
  if (/OPERATORS_/.test(expectedId)) {
    expectedId = 'OPERATORS_' + expectedId.slice('OPERATORS_'.length).replace(/_/g, '')
  }
  if (expectedId === 'MUSIC_SETTEMPO') expectedId = 'music.setTempo'

  if (expectedId === actualId) {
    continue // Already correct!
  }
  if (/\./.test(actualId)) {
    continue // Skip extension blocks for now.
  }
  console.log('category:   ', category)
  console.log('spec:       ', spec)
  console.log('s2 selector:', selector)
  console.log('s3 selector:')
  console.log('   expected ', expectedId)
  console.log('   actual   ', actualId)
  console.log('    comment:', map)
  console.log('')
}
```