### PR TITLE
Fix: convert space to newline in grouped selectors

### DIFF
--- a/scratch3/style.css.js
+++ b/scratch3/style.css.js
@@ -38,7 +38,8 @@ const commonOverride = `
   fill: #ffff80;
 }
 /* specificity */
-.sb3-comment-label, .sb3-label.sb3-comment-label {
+.sb3-comment-label,
+.sb3-label.sb3-comment-label {
   font: 400 12pt Helvetica Neue, Helvetica, sans-serif;
   fill: #000;
   word-spacing: 0;


### PR DESCRIPTION
Hello,
I noticed that the label color of comment blocks in my app differs from playground. Upon investigation, I found that it's because the HTML `<style>` is missing the styles for `.sb3-label.sb3-comment-label`. Although it does exist in the code, it seems that there might be an issue with how it's being parsed. Therefore, I've modified the selector group .sb3-comment-label, .sb3-label.sb3-comment-label, which previously had spaces between selectors, to use newlines instead. With this change, `.sb3-label.sb3-comment-label`  works properly on my app.

Thank you.

![image](https://github.com/scratchblocks/scratchblocks/assets/115907665/036f80a1-338e-4fc6-abfd-4008eae34606)
