### PR TITLE
Replace import assertions with import attributes

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,6 @@
 import babel from "@rollup/plugin-babel"
 import json from "@rollup/plugin-json"
-import pkg from "./package.json" assert { "type": "json" }
+import pkg from "./package.json" with { "type": "json" }
 import serve from "rollup-plugin-serve"
 import license from "rollup-plugin-license"
 import terser from "@rollup/plugin-terser"

--- a/tests/syntax.test.js
+++ b/tests/syntax.test.js
@@ -1,11 +1,11 @@
 import { parse, loadLanguages, allLanguages } from "../syntax"
 
-import de from "../locales/de.json" assert { "type": "json" }
-import ja from "../locales/ja.json" assert { "type": "json" }
-import ko from "../locales/ko.json" assert { "type": "json" }
-import pt_br from "../locales/pt-br.json" assert { "type": "json" }
-import rap from "../locales/rap.json" assert { "type": "json" }
-import uz from "../locales/uz.json" assert { "type": "json" }
+import de from "../locales/de.json" with { "type": "json" }
+import ja from "../locales/ja.json" with { "type": "json" }
+import ko from "../locales/ko.json" with { "type": "json" }
+import pt_br from "../locales/pt-br.json" with { "type": "json" }
+import rap from "../locales/rap.json" with { "type": "json" }
+import uz from "../locales/uz.json" with { "type": "json" }
 
 loadLanguages({
   de,


### PR DESCRIPTION
These no longer build in Node 22 since [import assertions were removed](https://github.com/nodejs/node/pull/52104).