### PR TITLE
Fix LOOKS_GOFORWARD_BACKWARDLAYERS translation for in pl.json

### DIFF
--- a/locales/pl.json
+++ b/locales/pl.json
@@ -31,7 +31,7 @@
     "LOOKS_CHANGESIZEBY": "zmień rozmiar o %1",
     "LOOKS_SETSIZETO": "ustaw rozmiar na %1 %",
     "LOOKS_GOTOFRONTBACK": "przesuń na %1",
-    "LOOKS_GOFORWARDBACKWARDLAYERS": "przesuń %1 o %2 warstw",
+    "LOOKS_GOFORWARDBACKWARDLAYERS": "przesuń do %1 o %2 warstw",
     "SOUND_PLAY": "zagraj dźwięk %1",
     "SOUND_CHANGEEFFECTBY": "zmień efekt %1 o %2",
     "SOUND_SETEFFECTO": "ustaw efekt %1 na %2",


### PR DESCRIPTION
It should be "przesuń do %1 o %2 warstw". This is what is used in Scratch. The current version "przesuń %1 o %2 warstw" is not grammatically correct.

![image](https://github.com/user-attachments/assets/218930e1-02bb-4be0-a38c-0399d8e280c2)
