### PR TITLE
Fix crash on `:: +`

### DIFF
--- a/scratch3/blocks.js
+++ b/scratch3/blocks.js
@@ -675,7 +675,7 @@ class GlowView {
     this.child.measure()
   }
 
-  drawSelf() {
+  drawSelf(iconStyle) {
     const c = this.child
     let el
     const w = this.width
@@ -689,7 +689,7 @@ class GlowView {
         el = SVG.stackRect(w, h)
       }
     } else {
-      el = c.drawSelf("", w, h, [])
+      el = c.drawSelf(iconStyle, w, h, [])
     }
     return SVG.setProps(el, {
       class: "sb3-diff sb3-diff-ins",
@@ -705,7 +705,7 @@ class GlowView {
     this.height = (c.isBlock && c.firstLine.height) || c.height
 
     // encircle
-    return SVG.group([el, this.drawSelf()])
+    return SVG.group([el, this.drawSelf(iconStyle)])
   }
 }
 

--- a/scratch3/blocks.js
+++ b/scratch3/blocks.js
@@ -605,7 +605,7 @@ class BlockView {
         objects.push(SVG.move(x, (line.y + y) | 0, child.el))
       }
     }
-
+    
     const el = this.drawSelf(iconStyle, innerWidth, this.height, lines)
     objects.splice(0, 0, el)
     if (this.info.color) {
@@ -689,7 +689,7 @@ class GlowView {
         el = SVG.stackRect(w, h)
       }
     } else {
-      el = c.drawSelf(w, h, [])
+      el = c.drawSelf('', w, h, [])
     }
     return SVG.setProps(el, {
       class: "sb3-diff sb3-diff-ins",

--- a/scratch3/blocks.js
+++ b/scratch3/blocks.js
@@ -605,7 +605,7 @@ class BlockView {
         objects.push(SVG.move(x, (line.y + y) | 0, child.el))
       }
     }
-    
+
     const el = this.drawSelf(iconStyle, innerWidth, this.height, lines)
     objects.splice(0, 0, el)
     if (this.info.color) {
@@ -689,7 +689,7 @@ class GlowView {
         el = SVG.stackRect(w, h)
       }
     } else {
-      el = c.drawSelf('', w, h, [])
+      el = c.drawSelf("", w, h, [])
     }
     return SVG.setProps(el, {
       class: "sb3-diff sb3-diff-ins",


### PR DESCRIPTION
Fixes a crash when using `::+`. scratch3 drawSelf takes an argument iconStyle, so this call was receiving the wrong arguments. 