### PR TITLE
Fix the stringify method of Comment class to remove excess spaces in label value

### DIFF
--- a/syntax/model.js
+++ b/syntax/model.js
@@ -312,7 +312,7 @@ export class Comment {
   }
 
   stringify() {
-    return `// ${this.label.value}`
+    return `// ${this.label.value.trim()}`
   }
 }
 


### PR DESCRIPTION
Fix the stringify method of Comment class to remove excess spaces in label value.