### PR TITLE
Fix Custom Block Color for High Contrast

### DIFF
--- a/scratch3/style.css.js
+++ b/scratch3/style.css.js
@@ -203,7 +203,7 @@ const highContrastStyle = {
 
   customPrimary: "#ff99aa",
   customSecondary: "#ffccd5",
-  customTertiary: "#e64d00",
+  customTertiary: "#ff3355",
 
   extensionPrimary: "#13ecaf",
   extensionSecondary: "#75f0cd",


### PR DESCRIPTION
There seems to have been a copy-paste error from the list blocks for the tertiary color of custom blocks in high contrast mode, resulting a really ugly-looking orange color (especially for empty inputs).