### PR TITLE
Fix dropdown menu spacing

### DIFF
--- a/scratch3/blocks.js
+++ b/scratch3/blocks.js
@@ -204,7 +204,7 @@ export class InputView {
         // Minimum padding of 11
         // Minimum width of 40, at which point we center the label
         px = this.label.width >= 18 ? 11 : (40 - this.label.width) / 2
-        w = this.label.width + (2 * px)
+        w = this.label.width + 2 * px
       }
       label = SVG.move(px, 9, label)
     } else {


### PR DESCRIPTION
The previous spacing calculation was only meant for regular inputs, but dropdown inputs also used it, leading to weird spacing when the text inside of the dropdown was too small.