### PR TITLE
Fix dropdown arrow's y position

### DIFF
--- a/scratch3/blocks.js
+++ b/scratch3/blocks.js
@@ -260,7 +260,7 @@ export class InputView {
       result.appendChild(
         SVG.move(
           w - 24,
-          13,
+          12.8505114083, // (12 - ((12 / 12.71) * 8.79)) / 2 + 11
           SVG.symbol(
             iconStyle === "high-contrast"
               ? "#sb3-dropdownArrow-high-contrast"

--- a/scratch3/style.js
+++ b/scratch3/style.js
@@ -417,7 +417,7 @@ export default class Style {
         ]),
         {
           id: "sb3-dropdownArrow",
-          transform: "scale(0.944)",
+          transform: "scale(0.94413847364)", // 12 / 12.71
         },
       ),
 


### PR DESCRIPTION
This fix should make every single vanilla block generated in scratchblocks look exactly the same (or close enough that I can't tell while magnifying the block to 500% and using a comparison tool).