### PR TITLE
Fix: translate blocks inside custom block calls

### DIFF
--- a/syntax/model.js
+++ b/syntax/model.js
@@ -241,6 +241,13 @@ export class Block {
         this.children.push(new Label(word))
       }
       return
+    } else if (id === "PROCEDURES_CALL") {
+      this.children.forEach(child => {
+        if (!child.isLabel && !child.isIcon) {
+          child.translate(lang)
+        }
+      })
+      return
     }
 
     const oldSpec = this.info.language.commands[id]

--- a/syntax/syntax.js
+++ b/syntax/syntax.js
@@ -823,6 +823,7 @@ function recogniseStuff(scripts) {
         // custom blocks
         const info = customBlocksByHash[block.info.hash]
         if (info) {
+          block.info.id = "PROCEDURES_CALL"
           block.info.selector = "call"
           block.info.call = info.spec
           block.info.names = info.names


### PR DESCRIPTION
Fix #396 

This issue was caused by custom block call blocks lacking an `info.id,` while the translate method checks for a non-empty `info.id`.

This pull request assigns id as `PROCEDURES_CALL` for custom block call blocks, and adds special handling in the translate method to only translate child blocks.