### PR TITLE
Improve Chinese Aliases

### DIFF
--- a/locales-src/extra_aliases.js
+++ b/locales-src/extra_aliases.js
@@ -69,6 +69,7 @@ export default {
     // Chinese (simplified)
     "左转 %1 度": "MOTION_TURNLEFT",
     "右转 %1 度": "MOTION_TURNRIGHT",
+    当绿旗被点击: "EVENT_WHENFLAGCLICKED",
     点击绿旗时: "EVENT_WHENFLAGCLICKED",
     结束: "scratchblocks:end",
   },
@@ -77,6 +78,7 @@ export default {
     // Chinese (traditional)
     "左轉 %1 度": "MOTION_TURNLEFT",
     "右轉 %1 度": "MOTION_TURNRIGHT",
+    當綠旗被點擊: "EVENT_WHENFLAGCLICKED",
     當綠旗被點擊時: "EVENT_WHENFLAGCLICKED",
     結束: "scratchblocks:end",
   },

--- a/locales/zh-cn.json
+++ b/locales/zh-cn.json
@@ -258,6 +258,7 @@
   "aliases": {
     "左转 %1 度": "MOTION_TURNLEFT",
     "右转 %1 度": "MOTION_TURNRIGHT",
+    "当绿旗被点击": "EVENT_WHENFLAGCLICKED",
     "点击绿旗时": "EVENT_WHENFLAGCLICKED",
     "结束": "scratchblocks:end"
   },

--- a/locales/zh-tw.json
+++ b/locales/zh-tw.json
@@ -258,6 +258,7 @@
   "aliases": {
     "左轉 %1 度": "MOTION_TURNLEFT",
     "右轉 %1 度": "MOTION_TURNRIGHT",
+    "當綠旗被點擊": "EVENT_WHENFLAGCLICKED",
     "當綠旗被點擊時": "EVENT_WHENFLAGCLICKED",
     "結束": "scratchblocks:end"
   },


### PR DESCRIPTION
### Background  
In the current Chinese translation of Scratchblocks, the alias is `点击绿旗时`, which is not entirely accurate and may cause confusion. The official Scratch interface and the broader Chinese community consistently use `当绿旗被点击`, which better reflects the original meaning.

### Changes  
- Added new Chinese alias: `当绿旗被点击`
- Retained the existing alias: `点击绿旗时` (to avoid breaking compatibility with existing scripts)

### Rationale  
- As a native Chinese speaker, I can confirm that `当绿旗被点击` is the more accurate and natural phrasing.  
- Online tutorials, forums, and the Scratch community widely use `当绿旗被点击`, making it the standard expression.  
- Keeping the old alias ensures backward compatibility for current users.  
- This change improves user experience by making the block’s trigger condition clearer for Chinese users.

### Supplementary Evidence  
To further support this change, here are some screenshots showing that the Chinese Scratch community widely uses `当绿旗被点击` in tutorials and discussions.

![1](https://github.com/user-attachments/assets/d3cfffbf-2c67-4f8c-bc2f-159ebe3b1949)
![3](https://github.com/user-attachments/assets/517cffa8-ac22-4f08-9522-9b6b12bbe5fa)
![2](https://github.com/user-attachments/assets/a8e32ca2-ceba-4896-bd19-5d40d18d19bf)

### Request  
Please review and approve this translation update to improve the experience for Chinese-speaking Scratch users.
