### PR TITLE
Optimize overrides logic to avoid unnecessary repeated assignments

### DIFF
--- a/syntax/blocks.js
+++ b/syntax/blocks.js
@@ -453,17 +453,23 @@ export function lookupDropdown(name, languages) {
 }
 
 export function applyOverrides(info, overrides) {
+  // Save the original category and shape to determine if overrides match defaults
+  const originalCategory = info.categoryIsDefault ? info.category : null
+  const originalShape = info.shapeIsDefault !== false ? info.shape : null
+  
   for (const name of overrides) {
     if (hexColorPat.test(name)) {
       info.color = name
       info.category = ""
       info.categoryIsDefault = false
-    } else if (overrideCategories.includes(name) && info.categoryIsDefault && info.category !== name) {
+    } else if (overrideCategories.includes(name) && info.category !== name) {
       info.category = name
-      info.categoryIsDefault = false
-    } else if (overrideShapes.includes(name) && info.shapeIsDefault !== false && info.shape !== name) {
+      // If the override matches the original category, keep categoryIsDefault as true
+      info.categoryIsDefault = (originalCategory !== null && name === originalCategory)
+    } else if (overrideShapes.includes(name) && info.shape !== name) {
       info.shape = name
-      info.shapeIsDefault = false
+      // If the override matches the original shape, keep shapeIsDefault as true
+      info.shapeIsDefault = (originalShape !== null && name === originalShape)
     } else if (name === "loop") {
       info.hasLoopArrow = true
     } else if (name === "+" || name === "-") {

--- a/syntax/blocks.js
+++ b/syntax/blocks.js
@@ -458,10 +458,10 @@ export function applyOverrides(info, overrides) {
       info.color = name
       info.category = ""
       info.categoryIsDefault = false
-    } else if (overrideCategories.includes(name) && info.category !== name) {
+    } else if (overrideCategories.includes(name) && info.categoryIsDefault && info.category !== name) {
       info.category = name
       info.categoryIsDefault = false
-    } else if (overrideShapes.includes(name) && info.shape !== name) {
+    } else if (overrideShapes.includes(name) && info.shapeIsDefault !== false && info.shape !== name) {
       info.shape = name
       info.shapeIsDefault = false
     } else if (name === "loop") {

--- a/syntax/blocks.js
+++ b/syntax/blocks.js
@@ -458,10 +458,10 @@ export function applyOverrides(info, overrides) {
       info.color = name
       info.category = ""
       info.categoryIsDefault = false
-    } else if (overrideCategories.includes(name)) {
+    } else if (overrideCategories.includes(name) && info.category !== name) {
       info.category = name
       info.categoryIsDefault = false
-    } else if (overrideShapes.includes(name)) {
+    } else if (overrideShapes.includes(name) && info.shape !== name) {
       info.shape = name
       info.shapeIsDefault = false
     } else if (name === "loop") {


### PR DESCRIPTION
before:
<img width="761" height="94" alt="image" src="https://github.com/user-attachments/assets/fc7918e1-4649-438a-93c8-f840a9be740b" />

after:
<img width="758" height="96" alt="image" src="https://github.com/user-attachments/assets/5eca8fb8-ceea-46e9-8b31-58b01f22ff92" />
