### PR TITLE
Remove extra spaces from comments

### DIFF
--- a/syntax/model.js
+++ b/syntax/model.js
@@ -325,7 +325,7 @@ export class Block {
 
 export class Comment {
   constructor(value, hasBlock) {
-    this.label = new Label(value, "comment-label")
+    this.label = new Label(value.trim(), "comment-label")
     this.width = null
     this.hasBlock = hasBlock
   }


### PR DESCRIPTION
before:
<img width="1612" height="173" alt="image" src="https://github.com/user-attachments/assets/bed0fc93-5f30-4d26-af8f-7dc5c6b8d18a" />
<img width="1605" height="187" alt="image" src="https://github.com/user-attachments/assets/94faa701-679f-4d41-8a56-ce6a2edfaf7c" />

after:
<img width="1632" height="183" alt="image" src="https://github.com/user-attachments/assets/ad78ab05-196d-4045-b920-b0931aba446f" />
<img width="1606" height="190" alt="image" src="https://github.com/user-attachments/assets/ec43205f-e569-424b-8687-49b0fa0cbc7b" />
