### PR TITLE
Add category aliases

### DIFF
--- a/syntax/blocks.js
+++ b/syntax/blocks.js
@@ -21,6 +21,11 @@ const overrideCategories = [
   ...Object.keys(aliasExtensions),
 ]
 
+export const aliasCategories = {
+  gray: "grey",
+  other: "grey",
+}
+
 const overrideShapes = [
   "hat",
   "cap",
@@ -457,6 +462,12 @@ export function applyOverrides(info, overrides) {
     if (hexColorPat.test(name)) {
       info.color = name
       info.category = ""
+      info.categoryIsDefault = false
+    } else if (
+      aliasCategories[name] &&
+      overrideCategories.includes(aliasCategories[name])
+    ) {
+      info.category = aliasCategories[name]
       info.categoryIsDefault = false
     } else if (overrideCategories.includes(name)) {
       info.category = name

--- a/syntax/syntax.js
+++ b/syntax/syntax.js
@@ -26,6 +26,7 @@ import {
   rtlLanguages,
   iconPat,
   blockName,
+  aliasCategories,
 } from "./blocks.js"
 
 function paintBlock(info, children, languages) {
@@ -64,7 +65,12 @@ function paintBlock(info, children, languages) {
       ) {
         info.shape = type.shape
       }
-      info.category = type.category
+      console.log('alias', aliasCategories[type.category])
+      if (aliasCategories[type.category]) {
+        info.category = aliasCategories[type.category]
+      } else {
+        info.category = type.category
+      }
       info.categoryIsDefault = true
       // store selector, used for translation among other things
       if (type.selector) {


### PR DESCRIPTION
This adds the category alias system I made for snapblocks, which allows for `grey` and `gray` (I also added `other` because that's the name of the grey category in snap). This system also doesn't need to have duplicate css rules for all the block styles because it just uses the actual category in place of the alias.