### PR TITLE
NPM publishing with OIDC

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -5,16 +5,19 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    environment: NPM
+    permissions:
+      id-token: write # Required for trusted publishing with OIDC
+      contents: read
     steps:
       - uses: actions/checkout@v6
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v6
         with:
           node-version: 24
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false # never cache in release builds
       - run: npm ci
-      - name: Disable AppArmor restriction
-        run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
+      - run: npm run build --if-present
+      - run: npm test
       - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This PR updates our NPM publishing workflow to use **[trusted publishing with OIDC](https://docs.npmjs.com/trusted-publishers)**. This seems to be the modern alternative to auth tokens — we don't need to store a long-lived token in CI secrets — and will supposedly automatically attach build provenance. Releases can then only be published from this CI workflow.

To be extra defensive, I've created a GHA environment called "NPM", and limited it to **selected branches & tags only** with the pattern `v*`.

(Note that our workflow triggers on `release: [published]`; the NPM example triggers on `push: tags: ["v*"]` instead. I think this is ok.)

I've also configured the package on NPM to use trusted publishing:

<img width="766" height="682" alt="Screenshot 2026-06-20 at 09 44 06" src="https://github.com/user-attachments/assets/144127f0-c574-4b42-8b89-3e453dd3882e" />

Once this is set up we can **delete the `NPM_TOKEN`** secret.